### PR TITLE
Battle Log - Solution A

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -259,7 +259,7 @@ func (c *battleContext) Opponents() []int {
 
 // An abstration over all possible actions an `Agent` can make in one round. Each Pokemon gets one turn.
 type Turn interface {
-	Priority() int // Gets the turn's priority. Higher values go first.
+	Priority() int // Gets the turn's priority. Higher values go first. Not to be confused with Move priority.
 }
 
 // Indicates that the Pokemon will fight. The active Pokemon indicated by `Self()` in the battle context will use

--- a/battle_test.go
+++ b/battle_test.go
@@ -66,7 +66,29 @@ func TestBattleOneRound(t *testing.T) {
 			t.Fatalf("Must send out first pokemon in each at the beginning of the battle. Party %d gave: %v", p, got)
 		}
 	}
-	b.SimulateRound()
+	turns := b.SimulateRound()
+	if len(turns) != 2 {
+		t.Fatal("Expected only 2 turns to occur in a round")
+	}
+	logtest := []struct {
+		turn Turn
+		want string
+	}{
+		{
+			turn: turns[0],
+			want: "Charmander used Pound on Squirtle for 3 damage.",
+		},
+		{
+			turn: turns[1],
+			want: "Squirtle used Pound on Charmander for 3 damage.",
+		},
+	}
+	for _, tt := range logtest {
+		got := tt.turn.BattleLog()
+		if got != tt.want {
+			t.Errorf("Expected battle log to be %s, got %s", tt.want, got)
+		}
+	}
 	// functionally arbitrary value, will need to be adjusted when damage calculation becomes more accurate
 	expectedHp := uint(27)
 	for _, party := range b.Parties {
@@ -74,10 +96,6 @@ func TestBattleOneRound(t *testing.T) {
 			t.Errorf("Expected %s to have %d HP, got %d", party.Pokemon[0].GetName(), expectedHp, party.Pokemon[0].CurrentHP)
 		}
 	}
-
-	// output:
-	// TODO: Implement fight {0 1}
-	// TODO: Implement fight {0 0}
 }
 
 // Faster pokemon should go first.


### PR DESCRIPTION
- adjust Turn priority documentation
- Add result field to Turns to be able to observe changes to battle state

closes #51
indirectly fixes #49
closes #69 

This is one of 2 possible implementations that I created for logging changes in the battle. (See #69)

This version adds a `BattleLog()` function to all Turns, which presents a human readable version of what 
happened in that turn. It also requires that all new turns include a `Result` field with all data that is 
required for a user to be able to observe changes to the battle state. (For example, animating moves).

### Benefits

- Very simple implementation

### Problems

- When we implement stuff like status effects we would have to create an extra turn to describe that change, 
because poison/burn damage happen at the end of the round.
- It'll be slightly harder for a user to process a turn that has multiple changes to the battle state, 
like a `FightTurn` that deals damage and also burns the target.
