### PR TITLE
Battle Log - Solution B

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -177,7 +177,7 @@ func (b *Battle) getContext(party *party, pokemon *Pokemon) *BattleContext {
 
 // An abstration over all possible actions an `Agent` can make in one round. Each Pokemon gets one turn.
 type Turn interface {
-	Priority() int // Gets the turn's priority. Higher values go first.
+	Priority() int // Gets the turn's priority. Higher values go first. Not to be confused with Move priority.
 }
 
 // Wrapper used to determine turn order in a battle

--- a/battle.go
+++ b/battle.go
@@ -211,7 +211,7 @@ func (turn FightTurn) Priority() int {
 	return 0
 }
 
-// Describes the result of a Turn in a Round.
+// Describes a change to battle state.
 type Transaction interface {
 	BattleLog() string
 }

--- a/battle_test.go
+++ b/battle_test.go
@@ -200,7 +200,7 @@ func TestPokemonSpeed(t *testing.T) {
 	pkmn1.Stats = [6]uint{30, 10, 10, 10, 10, 10}
 	party1.AddPokemon(&pkmn1)
 	party2 := NewParty(&a2, 1)
-	pkmn2 := GetPokemon(4)
+	pkmn2 := GetPokemon(7)
 	pkmn2.Moves[0] = &pound
 	pkmn2.Stats = [6]uint{30, 10, 10, 10, 10, 12}
 	party2.AddPokemon(&pkmn2)

--- a/battle_test.go
+++ b/battle_test.go
@@ -61,20 +61,20 @@ func TestBattleOneRound(t *testing.T) {
 			t.Fatalf("Must send out first pokemon in each at the beginning of the battle. Party %d gave: %v", p, got)
 		}
 	}
-	transations := b.SimulateRound()
-	if len(transations) != 2 {
-		t.Fatal("Expected only 2 transations to occur in a round")
+	transactions := b.SimulateRound()
+	if len(transactions) != 2 {
+		t.Fatal("Expected only 2 transactions to occur in a round")
 	}
 	logtest := []struct {
 		turn Transaction
 		want string
 	}{
 		{
-			turn: transations[0],
+			turn: transactions[0],
 			want: "Charmander used Pound on Squirtle for 3 damage.",
 		},
 		{
-			turn: transations[1],
+			turn: transactions[1],
 			want: "Squirtle used Pound on Charmander for 3 damage.",
 		},
 	}
@@ -211,20 +211,20 @@ func TestPokemonSpeed(t *testing.T) {
 		t.Fatal("failed to start battle")
 	}
 
-	transations := b.SimulateRound()
-	if len(transations) != 2 {
-		t.Fatal("Expected only 2 transations to occur in a round")
+	transactions := b.SimulateRound()
+	if len(transactions) != 2 {
+		t.Fatal("Expected only 2 transactions to occur in a round")
 	}
 	logtest := []struct {
 		turn Transaction
 		want string
 	}{
 		{
-			turn: transations[0],
+			turn: transactions[0],
 			want: "Squirtle used Pound on Charmander for 3 damage.",
 		},
 		{
-			turn: transations[1],
+			turn: transactions[1],
 			want: "Charmander used Pound on Squirtle for 3 damage.",
 		},
 	}

--- a/battle_test.go
+++ b/battle_test.go
@@ -92,10 +92,6 @@ func TestBattleOneRound(t *testing.T) {
 			t.Errorf("Expected %s to have %d HP, got %d", party.pokemon[0].GetName(), expectedHp, party.pokemon[0].CurrentHP)
 		}
 	}
-
-	// output:
-	// TODO: Implement fight {0 1}
-	// TODO: Implement fight {0 0}
 }
 
 // Tests if active Pokemon are set correctly
@@ -214,13 +210,30 @@ func TestPokemonSpeed(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to start battle")
 	}
-	b.SimulateRound()
-	b.SimulateRound()
-	// FIXME: ideally should check battle log/history
-	// FIXME: For some reason, the output is not actually checked correctly, see #49
-	// Output:
-	// TODO: Implement fight {0 0}
-	// TODO: Implement fight {0 1}
+
+	transations := b.SimulateRound()
+	if len(transations) != 2 {
+		t.Fatal("Expected only 2 transations to occur in a round")
+	}
+	logtest := []struct {
+		turn Transaction
+		want string
+	}{
+		{
+			turn: transations[0],
+			want: "Squirtle used Pound on Charmander for 3 damage.",
+		},
+		{
+			turn: transations[1],
+			want: "Charmander used Pound on Squirtle for 3 damage.",
+		},
+	}
+	for _, tt := range logtest {
+		got := tt.turn.BattleLog()
+		if got != tt.want {
+			t.Errorf("Expected battle log to be %s, got %s", tt.want, got)
+		}
+	}
 }
 
 func TestTurnPriority(t *testing.T) {

--- a/battle_test.go
+++ b/battle_test.go
@@ -61,7 +61,30 @@ func TestBattleOneRound(t *testing.T) {
 			t.Fatalf("Must send out first pokemon in each at the beginning of the battle. Party %d gave: %v", p, got)
 		}
 	}
-	b.SimulateRound()
+	transations := b.SimulateRound()
+	if len(transations) != 2 {
+		t.Fatal("Expected only 2 transations to occur in a round")
+	}
+	logtest := []struct {
+		turn Transaction
+		want string
+	}{
+		{
+			turn: transations[0],
+			want: "Charmander used Pound on Squirtle for 3 damage.",
+		},
+		{
+			turn: transations[1],
+			want: "Squirtle used Pound on Charmander for 3 damage.",
+		},
+	}
+	for _, tt := range logtest {
+		got := tt.turn.BattleLog()
+		if got != tt.want {
+			t.Errorf("Expected battle log to be %s, got %s", tt.want, got)
+		}
+	}
+
 	// functionally arbitrary value, will need to be adjusted when damage calculation becomes more accurate
 	expectedHp := uint(27)
 	for _, party := range b.parties {


### PR DESCRIPTION
- adjust Turn priority documentation
- Implement a transation based approach to modifying battle state

closes #51
indirectly fixes #49
closes #68 

This is one of 2 possible implementations that I created for logging changes in the battle. (See #68)

This takes a transaction based approach to implementing a battle log. This adds a new `Transaction`
interface that works somewhat similarly to how the `Turn` interface works. A `Transaction` represents
a change to the battle state, which can occur as a result of an agent's turn, or automatically (like
the burn status effect wearing off).

### Benefits

- It's more clear how to implement end-of-turn status effects.
- It's seperates state changes into single operations, which is probably easier for a user to process.
- There's no possibility that an Agent could submit a Turn that included a Result that it is not supposed to have.
- It's more clear how to indicate to the user that the battle has ended.

### Problems

- It makes the implementation of somewhat basic things a bit more complex and verbose.
