### PR TITLE
remove all t.Parallel() from tests because coverage was not being collected correctly

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -248,7 +248,6 @@ func TestTurnPriority(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%T priority", tt.turn), func(t *testing.T) {
-			t.Parallel()
 			got := tt.turn.Priority()
 			if got != tt.want {
 				t.Errorf("TurnPriority(%T) got %v, want %v", tt.turn, got, tt.want)

--- a/gender_test.go
+++ b/gender_test.go
@@ -29,7 +29,6 @@ func TestGenderString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Gender Stringer: %s", tt.name), func(t *testing.T) {
-			t.Parallel()
 			got := fmt.Sprintf("%s", tt.gender)
 			if got != tt.want {
 				t.Errorf("Gender Stringer %s got %v, want %v", tt.name, got, tt.want)

--- a/move_test.go
+++ b/move_test.go
@@ -32,7 +32,6 @@ func TestMoveString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Move Stringer: %s", tt.move.Name), func(t *testing.T) {
-			t.Parallel()
 			got := fmt.Sprintf("%s", tt.move)
 			if got != tt.want {
 				t.Errorf("Move Stringer %s got %v, want %v", tt.move.Name, got, tt.want)
@@ -61,7 +60,6 @@ func TestMoveCategoryString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("MoveCategory Stringer: %s", tt.want), func(t *testing.T) {
-			t.Parallel()
 			got := tt.value.String()
 			if got != tt.want {
 				t.Errorf("Move Category (%d) got %v, want %v", tt.value, got, tt.want)

--- a/pokemon_test.go
+++ b/pokemon_test.go
@@ -37,7 +37,6 @@ func TestPokemonStringer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Pokemon Stringer: %d", tt.pkmn.NatDex), func(t *testing.T) {
-			t.Parallel()
 			got := fmt.Sprintf("%s", tt.pkmn)
 			if got != tt.want {
 				t.Errorf("Pokemon Stringer %d got %v, want %v", tt.pkmn.NatDex, got, tt.want)


### PR DESCRIPTION
I've found that calling `t.Parallel()` causes test coverage to be collected incorrectly sometimes.﻿
