### PR TITLE
Golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,6 @@
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+      - gosimple
+      text: "S1025"


### PR DESCRIPTION
Config file to disable linting rule(s) in test files. I recommend this as a linter for this project, as this config will allow us to customize what rules are enforced/ignored: https://golangci-lint.run/