### PR TITLE
GetMove returns *Move

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -52,11 +52,8 @@ func TestRcAgent(t *testing.T) {
 	a2 := newRcAgent()
 	_a1 := Agent(a1)
 	_a2 := Agent(a2)
-	pound := GetMove(MOVE_POUND)
-	pkmn1 := GeneratePokemon(4)
-	pkmn1.Moves[0] = &pound
-	pkmn2 := GeneratePokemon(7)
-	pkmn2.Moves[0] = &pound
+	pkmn1 := GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND)))
+	pkmn2 := GeneratePokemon(7, WithMoves(GetMove(MOVE_POUND)))
 	party1 := NewOccupiedParty(&_a1, 0, pkmn1)
 	party2 := NewOccupiedParty(&_a2, 1, pkmn2)
 	b := NewBattle()
@@ -138,16 +135,14 @@ var _ = Describe("One round of battle", func() {
 		battle     *Battle
 		charmander *Pokemon
 		squirtle   *Pokemon
-		pound      Move
 	)
 
 	BeforeEach(func() {
 		agent1 = Agent(dumbAgent{})
 		agent2 = Agent(dumbAgent{})
-		pound = GetMove(MOVE_POUND)
-		charmander = GeneratePokemon(4, WithMoves(&pound))
+		charmander = GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND)))
 		party1 = NewOccupiedParty(&agent1, 0, charmander)
-		squirtle = GeneratePokemon(7, WithMoves(&pound))
+		squirtle = GeneratePokemon(7, WithMoves(GetMove(MOVE_POUND)))
 		party2 = NewOccupiedParty(&agent2, 1, squirtle)
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
@@ -190,8 +185,7 @@ var _ = Describe("One round of battle", func() {
 		It("should account for same-type attack bonus", func() {
 			// TODO: remove when elemental type added
 			charmander.Elemental = Fire
-			ember := GetMove(52)
-			charmander.Moves[0] = &ember
+			charmander.Moves[0] = GetMove(MOVE_EMBER)
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
 			Expect(squirtle.CurrentHP).To(BeEquivalentTo(6))
@@ -363,12 +357,10 @@ var _ = Describe("Move priority", func() {
 	})
 
 	Specify("Moves with higher priority should go first", func() {
-		pound := GetMove(1)
-		p1 := GeneratePokemon(1, WithLevel(5), WithMoves(&pound))
+		p1 := GeneratePokemon(1, WithLevel(5), WithMoves(GetMove(MOVE_POUND)))
 		p1.Stats[STAT_SPD] = 100
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		fakeout := GetMove(252)
-		p2 := GeneratePokemon(4, WithLevel(5), WithMoves(&fakeout))
+		p2 := GeneratePokemon(4, WithLevel(5), WithMoves(GetMove(MOVE_FAKE_OUT)))
 		p2.Stats[STAT_SPD] = 10
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
@@ -402,16 +394,14 @@ var _ = Describe("Pokemon speed", func() {
 		agent2 Agent
 		party1 *party
 		party2 *party
-		pound  Move
 		battle *Battle
 	)
 
 	BeforeEach(func() {
 		agent1 = Agent(dumbAgent{})
 		agent2 = Agent(dumbAgent{})
-		pound = GetMove(MOVE_POUND)
-		party1 = NewOccupiedParty(&agent1, 0, GeneratePokemon(4, WithMoves(&pound)))
-		party2 = NewOccupiedParty(&agent2, 1, GeneratePokemon(291, WithMoves(&pound))) // ninjask is faster than charmander
+		party1 = NewOccupiedParty(&agent1, 0, GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND))))
+		party2 = NewOccupiedParty(&agent2, 1, GeneratePokemon(291, WithMoves(GetMove(MOVE_POUND)))) // ninjask is faster than charmander
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
 	})
@@ -468,10 +458,12 @@ var _ = Describe("Fainting", func() {
 	BeforeEach(func() {
 		agent1 = Agent(dumbAgent{})
 		agent2 = Agent(dumbAgent{})
-		pound = GetMove(MOVE_POUND)
-		scary_monster := GeneratePokemon(7, WithLevel(100), WithMoves(&pound))
+		scary_monster := GeneratePokemon(7, WithLevel(100), WithMoves(GetMove(MOVE_POUND)))
 		scary_monster.Stats[STAT_SPD] = 1
-		party1 = NewOccupiedParty(&agent1, 0, GeneratePokemon(4, WithMoves(&pound)), GeneratePokemon(387, WithMoves(&pound)))
+		party1 = NewOccupiedParty(&agent1, 0,
+			GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND))),
+			GeneratePokemon(387, WithMoves(&pound)),
+		)
 		party2 = NewOccupiedParty(&agent2, 1, scary_monster)
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
@@ -547,15 +539,12 @@ var _ = Describe("Fainting", func() {
 		a1 := Agent(dumbAgent{})
 		a2 := Agent(dumbAgent{})
 		party1 := NewParty(&a1, 0)
-		pkmn1 := GeneratePokemon(4, WithLevel(3))
+		pkmn1 := GeneratePokemon(4, WithLevel(3), WithMoves(GetMove(MOVE_POUND)))
 		pkmn1.CurrentHP = 1
-		pound := GetMove(MOVE_POUND)
-		pkmn1.Moves[0] = &pound
 		party1.AddPokemon(pkmn1)
 		party2 := NewParty(&a2, 1)
-		pkmn2 := GeneratePokemon(7, WithLevel(10))
+		pkmn2 := GeneratePokemon(7, WithLevel(10), WithMoves(GetMove(MOVE_POUND)))
 		pkmn2.Stats[STAT_SPD] = 255
-		pkmn2.Moves[0] = &pound
 		party2.AddPokemon(pkmn2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -589,17 +578,13 @@ var _ = Describe("Fainting", func() {
 		a1 := Agent(dumbAgent{})
 		a2 := Agent(dumbAgent{})
 		party1 := NewParty(&a1, 0)
-		pkmn1 := GeneratePokemon(4, WithLevel(3))
-		pkmn3 := GeneratePokemon(387, WithLevel(3))
+		pkmn1 := GeneratePokemon(4, WithLevel(3), WithMoves(GetMove(MOVE_POUND)))
+		pkmn2 := GeneratePokemon(7, WithLevel(10), WithMoves(GetMove(MOVE_POUND)))
+		pkmn3 := GeneratePokemon(387, WithLevel(3), WithMoves(GetMove(MOVE_POUND)))
 		pkmn1.CurrentHP = 1
-		pound := GetMove(MOVE_POUND)
-		pkmn1.Moves[0] = &pound
-		pkmn3.Moves[0] = &pound
 		party1.AddPokemon(pkmn1, pkmn3)
 		party2 := NewParty(&a2, 1)
-		pkmn2 := GeneratePokemon(7, WithLevel(10))
 		pkmn2.Stats[STAT_SPD] = 255
-		pkmn2.Moves[0] = &pound
 		party2.AddPokemon(pkmn2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -637,17 +622,15 @@ var _ = Describe("Ending a battle", func() {
 		party1 *party
 		party2 *party
 		battle *Battle
-		pound  Move
 	)
 
 	BeforeEach(func() {
 		agent1 = Agent(dumbAgent{})
 		agent2 = Agent(dumbAgent{})
-		pound = GetMove(MOVE_POUND)
-		low_health_pkmn := GeneratePokemon(4, WithMoves(&pound))
+		low_health_pkmn := GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND)))
 		low_health_pkmn.CurrentHP = 1
 		party1 = NewOccupiedParty(&agent1, 0, low_health_pkmn)
-		party2 = NewOccupiedParty(&agent2, 1, GeneratePokemon(7, WithMoves(&pound)))
+		party2 = NewOccupiedParty(&agent2, 1, GeneratePokemon(7, WithMoves(GetMove(MOVE_POUND))))
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
 	})
@@ -699,13 +682,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	It("should inflict burn and poison damage", func() {
-		pound := GetMove(MOVE_POUND)
-		p1 := GeneratePokemon(1)
-		p1.Moves[0] = &pound
+		p1 := GeneratePokemon(1, WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusPoison
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(2)
-		p2.Moves[0] = &pound
+		p2 := GeneratePokemon(2, WithMoves(GetMove(MOVE_POUND)))
 		p2.StatusEffects = StatusBurn
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
@@ -733,13 +713,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	It("should inflict badly poisoned damage", func() {
-		p1 := GeneratePokemon(1, WithLevel(8))
-		pound := GetMove(MOVE_POUND)
-		p1.Moves[0] = &pound
+		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusBadlyPoison
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(2)
-		p2.Moves[0] = &pound
+		p2 := GeneratePokemon(2, WithMoves(GetMove(MOVE_POUND)))
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -762,11 +739,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	Specify("Paralysis", func() {
-		pound := GetMove(1)
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(&pound))
+		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusParalyze
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(&pound))
+		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MOVE_POUND)))
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -778,11 +754,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	Specify("Freeze", func() {
-		pound := GetMove(1)
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(&pound))
+		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusFreeze
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(&pound))
+		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MOVE_POUND)))
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -794,11 +769,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	Specify("Sleep", func() {
-		pound := GetMove(1)
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(&pound))
+		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusSleep
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(&pound))
+		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MOVE_POUND)))
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
 		b.AddParty(party1, party2)
@@ -810,11 +784,10 @@ var _ = Describe("Status Conditions", func() {
 	})
 
 	It("Should cure paralysis", func() {
-		pound := GetMove(1)
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(&pound))
+		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MOVE_POUND)))
 		p1.StatusEffects = StatusParalyze
 		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(&pound))
+		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MOVE_POUND)))
 		party2 := NewOccupiedParty(&a2, 1, p2)
 		b := NewBattle()
 		b.AddParty(party1, party2)

--- a/battle_test.go
+++ b/battle_test.go
@@ -452,7 +452,6 @@ var _ = Describe("Fainting", func() {
 		party1 *party
 		party2 *party
 		battle *Battle
-		pound  Move
 	)
 
 	BeforeEach(func() {
@@ -462,7 +461,7 @@ var _ = Describe("Fainting", func() {
 		scary_monster.Stats[STAT_SPD] = 1
 		party1 = NewOccupiedParty(&agent1, 0,
 			GeneratePokemon(4, WithMoves(GetMove(MOVE_POUND))),
-			GeneratePokemon(387, WithMoves(&pound)),
+			GeneratePokemon(387, WithMoves(GetMove(MOVE_POUND))),
 		)
 		party2 = NewOccupiedParty(&agent2, 1, scary_monster)
 		battle = NewBattle()
@@ -508,10 +507,10 @@ var _ = Describe("Fainting", func() {
 
 	Context("Fainting causes friendship to be lost", func() {
 		It("should lose 1 friendship when fainting", func() {
-			dies := GeneratePokemon(1, WithLevel(1), WithMoves(&pound))
+			dies := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MOVE_POUND)))
 			dies.Friendship = 100
 			p1 := NewOccupiedParty(&agent1, 0, dies)
-			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(25), WithMoves(&pound)))
+			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(25), WithMoves(GetMove(MOVE_POUND))))
 			battle = NewBattle()
 			battle.AddParty(p1, p2)
 			Expect(battle.Start()).To(Succeed())
@@ -519,12 +518,12 @@ var _ = Describe("Fainting", func() {
 			Expect(dies.Friendship).To(Equal(99))
 		})
 		It("should lose 5 or 10 friendship when fainting", func() {
-			dies := GeneratePokemon(1, WithLevel(1), WithMoves(&pound))
+			dies := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MOVE_POUND)))
 			dies.Friendship = 100
-			dies2 := GeneratePokemon(1, WithLevel(1), WithMoves(&pound))
+			dies2 := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MOVE_POUND)))
 			dies2.Friendship = 200
 			p1 := NewOccupiedParty(&agent1, 0, dies, dies2)
-			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(100), WithMoves(&pound)))
+			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(100), WithMoves(GetMove(MOVE_POUND))))
 			battle = NewBattle()
 			battle.AddParty(p1, p2)
 			Expect(battle.Start()).To(Succeed())

--- a/move.go
+++ b/move.go
@@ -61,10 +61,10 @@ type Move struct {
 }
 
 // Retrieves a Pokemon move given its move ID
-func GetMove(id int) Move {
+func GetMove(id int) *Move {
 	for _, m := range ALL_MOVES {
 		if m.ID == id {
-			return m
+			return &m
 		}
 	}
 	panic("move not found")

--- a/pokemon_test.go
+++ b/pokemon_test.go
@@ -96,8 +96,8 @@ var _ = Describe("Pokemon generation", func() {
 	It("generates a Pokemon with a given moveset", func() {
 		pound := GetMove(MOVE_POUND)
 		pursuit := GetMove(MOVE_PURSUIT)
-		pkmn := GeneratePokemon(393, WithMoves(&pound, &pursuit))
-		Expect(pkmn.Moves).To(BeEquivalentTo([MAX_MOVES]*Move{&pound, &pursuit, nil, nil}))
+		pkmn := GeneratePokemon(393, WithMoves(pound, pursuit))
+		Expect(pkmn.Moves).To(BeEquivalentTo([MAX_MOVES]*Move{pound, pursuit, nil, nil}))
 	})
 
 	It("creates Pokemon with accurate stats reflecting its given values", func() {
@@ -142,7 +142,7 @@ var _ = Describe("Pokemon generation", func() {
 
 	It("panics when creating a Pokemon with more than the maximum allowed moves", func() {
 		pound := GetMove(MOVE_POUND)
-		Expect(func() { GeneratePokemon(396, WithMoves(&pound, &pound, &pound, &pound, &pound)) }).To(Panic())
+		Expect(func() { GeneratePokemon(396, WithMoves(pound, pound, pound, pound, pound)) }).To(Panic())
 	})
 })
 


### PR DESCRIPTION
All of the following methods except for GetMove return pointers:
- NewBattle
- NewParty
- NewOccupiedParty
- GeneratePokemon

I thought that this change would be more in-line with these other methods. A counterargument might be reusing the same move, but consider having to write this **always**:
```go
pound := GetMove(MOVE_POUND)
p := GeneratePokemon(1, WithMoves(&pound)
```
even if only needed once, whereas you can still do this if you want to reuse the move:
```go
pound := *GetMove(MOVE_POUND)
p1 := GeneratePokemon(1, WithMoves(&pound)
p2 := GeneratePokemon(2, WithMoves(&pound)
```