### PR TITLE
feat: TestRNG with 3 presets

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -146,7 +146,7 @@ var _ = Describe("One round of battle", func() {
 		party2 = NewOccupiedParty(&agent2, 1, squirtle)
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
-		battle.SetSeed(2)
+		battle.rng = &SimpleRNG
 	})
 
 	It("starts without error", func() {
@@ -217,26 +217,24 @@ var _ = Describe("One round of battle", func() {
 			adaptability := Ability{ID: 91}
 			charmander.Ability = &adaptability
 			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(86))
+			Expect(squirtle.CurrentHP).To(BeEquivalentTo(93))
 		})
 
 		It("should account for critical hits", func() {
+			battle.rng = &AlwaysRNG
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(8))
-			charmander.StatModifiers[STAT_CRIT_CHANCE] = 4 // 50% crit, max stage
-			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(1))
+			Expect(squirtle.CurrentHP).To(BeEquivalentTo(4))
 		})
 	})
 
 	Context("should account for accuracy/evasion", func() {
 		It("should miss moves randomly", func() {
+			battle.rng = &NeverRNG
 			Expect(battle.Start()).To(Succeed())
-			charmander.Moves[0].Accuracy = 1
 			logs, _ := battle.SimulateRound()
 			Expect(logs[0].BattleLog()).To(Equal("Charmander's attack missed!"))
-			charmander.Moves[0].Accuracy = 99
+			battle.rng = &SimpleRNG
 			logs, _ = battle.SimulateRound()
 			Expect(logs[0].BattleLog()).To(Equal("Charmander used Pound on Squirtle for 3 damage."))
 		})

--- a/util_test.go
+++ b/util_test.go
@@ -212,3 +212,24 @@ func (matcher *orderedTransactionMatcher) NegatedFailureMessage(actual interface
 		strings.Join(seq, "\n"),
 	)
 }
+
+// Tools for testing the library
+// Custom RNG struct which allows for predictable RNG output in a battle
+type TestRNG struct {
+	rolls  []bool
+	rounds int
+}
+
+func (g *TestRNG) SetSeed(uint) {}
+func (g *TestRNG) Get(min, max int) int {
+	return max
+}
+func (g *TestRNG) Roll(x, y int) bool {
+	v := g.rolls[g.rounds%len(g.rolls)]
+	g.rounds += 1
+	return v
+}
+
+var NeverRNG = TestRNG{rolls: []bool{false}}        // Never rolls random effects
+var AlwaysRNG = TestRNG{rolls: []bool{true}}        // Always rolls random effects
+var SimpleRNG = TestRNG{rolls: []bool{true, false}} // Always hit, never crit


### PR DESCRIPTION
This PR introduces a new format for predictability in testing battles. The `TestRNG` object can be created with `rolls`, which is a cyclical `[]bool` for predictable output from `rng.Roll`. Every time `rng.Roll` is called, the next value in the cycle is returned.

I came up with 3 presets that I think will be most commonly used for testing:
`NeverRNG`: forces basic attacks to miss, always returns false
`AlwaysRNG`: forces things like crits/modifiers to happen, always returns true
`SimpleRNG`: hard-coded to match a battle where no special events occur. currently this is {true, false} so that attacks always hit, but never crit

This PR also refactors one test group to demonstrate its use (with the intent of avoiding to guess a specific seed).

Closes #177