### PR TITLE
chore: simplify tests

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -73,34 +73,17 @@ var _ = Describe("RC Agent", func() {
 	}
 })
 
-var _ = Describe("Battle", func() {
-	var (
-		agent1 Agent
-		agent2 Agent
-	)
+var _ = Describe("Battle initialization", func() {
+	agent1 := Agent(new(dumbAgent))
+	agent2 := Agent(new(dumbAgent))
 
-	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
-	})
-
-	Context("Battle setup", func() {
+	Context("when creating a new battle", func() {
 		It("runs without panicking", func() {
 			party1 := NewOccupiedParty(&agent1, 0, GeneratePokemon(PkmnCharmander))
 			party2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(PkmnSquirtle))
 			b := NewBattle()
 			b.AddParty(party1, party2)
 			b.SetSeed(849823)
-		})
-
-		It("panics when adding too many Pokemon to a party", func() {
-			party := NewParty(&agent1, 0)
-			for i := 0; i < MaxPartySize; i += 1 {
-				party.AddPokemon(GeneratePokemon(PkmnBulbasaur))
-			}
-			Expect(func() {
-				party.AddPokemon(GeneratePokemon(PkmnBulbasaur))
-			}).To(Panic())
 		})
 
 		It("panics when getting an invalid Pokemon", func() {
@@ -118,9 +101,10 @@ var _ = Describe("Battle", func() {
 })
 
 var _ = Describe("One round of battle", func() {
+	agent1 := Agent(new(dumbAgent))
+	agent2 := Agent(new(dumbAgent))
+
 	var (
-		agent1     Agent
-		agent2     Agent
 		party1     *party
 		party2     *party
 		battle     *Battle
@@ -129,39 +113,28 @@ var _ = Describe("One round of battle", func() {
 	)
 
 	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
-		charmander = GeneratePokemon(4, WithMoves(GetMove(MovePound)))
+		charmander = GeneratePokemon(PkmnCharmander, WithMoves(GetMove(MovePound)))
 		party1 = NewOccupiedParty(&agent1, 0, charmander)
-		squirtle = GeneratePokemon(7, WithMoves(GetMove(MovePound)))
+		squirtle = GeneratePokemon(PkmnSquirtle, WithMoves(GetMove(MovePound)))
 		party2 = NewOccupiedParty(&agent2, 1, squirtle)
 		battle = NewBattle()
 		battle.AddParty(party1, party2)
 		battle.rng = &SimpleRNG
 	})
 
-	It("starts without error", func() {
-		err := battle.Start()
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-
-	It("panics if battle is not in progress", func() {
-		Expect(func() {
-			battle.SimulateRound()
-		}).To(Panic())
-	})
-
 	Context("when simulating a round between two agents", func() {
-		It("should return two transactions", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveLen(2))
+		It("panics if battle is not in progress", func() {
+			Expect(func() {
+				battle.SimulateRound()
+			}).To(Panic())
 		})
+
 		It("should create 2 damage transactions", func() {
 			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
+			t, _ := battle.SimulateRound()
+			Expect(t).To(HaveLen(2))
 			pound := GetMove(MovePound)
-			Expect(transactions).To(HaveTransaction(DamageTransaction{
+			Expect(t).To(HaveTransaction(DamageTransaction{
 				User: charmander,
 				Target: target{
 					Pokemon:   *squirtle,
@@ -172,7 +145,7 @@ var _ = Describe("One round of battle", func() {
 				Move:   pound,
 				Damage: 3,
 			}))
-			Expect(transactions).To(HaveTransaction(DamageTransaction{
+			Expect(t).To(HaveTransaction(DamageTransaction{
 				User: squirtle,
 				Target: target{
 					Pokemon:   *charmander,
@@ -184,6 +157,7 @@ var _ = Describe("One round of battle", func() {
 				Damage: 3,
 			}))
 		})
+
 		It("should cause Pokemon to have reduced HP", func() {
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
@@ -192,7 +166,7 @@ var _ = Describe("One round of battle", func() {
 		})
 	})
 
-	Context("should deal the correct amount of damage", func() {
+	Context("when dealing damage to a Pokemon", func() {
 		It("should account for same-type attack bonus", func() {
 			// TODO: remove when elemental type added
 			charmander.Type = TypeFire
@@ -213,10 +187,8 @@ var _ = Describe("One round of battle", func() {
 			battle.SimulateRound()
 			Expect(squirtle.CurrentHP).To(BeEquivalentTo(4))
 		})
-	})
 
-	Context("should account for accuracy/evasion", func() {
-		It("should miss moves randomly", func() {
+		It("should miss moves randomly based on accuracy/evasion", func() {
 			battle.rng = &NeverRNG
 			Expect(battle.Start()).To(Succeed())
 			t, _ := battle.SimulateRound()
@@ -231,8 +203,8 @@ var _ = Describe("One round of battle", func() {
 		})
 	})
 
-	Context("Interacts with StatModifiers in battle", func() {
-		It("should increase stat modifiers from certain moves", func() {
+	Context("when certain moves are used in battle", func() {
+		It("should change a Pokemon's stat modifiers", func() {
 			charmander.Moves[0] = GetMove(MoveHowl)
 			Expect(battle.Start()).To(Succeed())
 			t, _ := battle.SimulateRound()
@@ -255,29 +227,23 @@ var _ = Describe("One round of battle", func() {
 })
 
 var _ = Describe("Using items in battle", func() {
+	agent := Agent(new(healAgent))
 	var (
-		agent  Agent
 		pkmn   *Pokemon
 		party  *party
 		battle *Battle
 	)
 
 	BeforeEach(func() {
-		agent = Agent(healAgent{})
-		pkmn = GeneratePokemon(3, WithLevel(50))
+		pkmn = GeneratePokemon(PkmnVenusaur, WithLevel(50))
 		pkmn.CurrentHP = 10
 		party = NewOccupiedParty(&agent, 0, pkmn)
 		battle = NewBattle()
 		battle.AddParty(party)
-		battle.SetSeed(1337)
 	})
 
-	Context("an Agent uses an ItemTurn to use a Potion on a Pokemon", func() {
-		It("should run without error", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("should log ItemTurns correctly", func() {
+	Context("when the battle processes item turns", func() {
+		It("should create ItemTransaction(s) properly", func() {
 			Expect(battle.Start()).To(Succeed())
 			t, _ := battle.SimulateRound()
 			potion := GetItem(ItemPotion)
@@ -289,71 +255,25 @@ var _ = Describe("Using items in battle", func() {
 				},
 			))
 		})
+
 		It("should heal the Pokemon by 20 HP", func() {
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
-			Expect(int(pkmn.CurrentHP)).To(Equal(30))
+			Expect(pkmn.CurrentHP).To(BeEquivalentTo(30))
 		})
 	})
 })
 
-var _ = Describe("Active pokemon in battle", func() {
+var _ = Describe("Getting pokemon from parties", func() {
+	agent1 := Agent(new(dumbAgent))
+	agent2 := Agent(new(dumbAgent))
 	var (
-		agent Agent
-		party *party
-	)
-
-	BeforeEach(func() {
-		agent = Agent(dumbAgent{})
-		party = NewOccupiedParty(&agent, 0, GeneratePokemon(PkmnSquirtle), GeneratePokemon(PkmnBlastoise))
-	})
-
-	It("should add an active Pokemon when SetActive is called", func() {
-		party.SetActive(0)
-		Expect(party.GetActivePokemon()).To(HaveLen(1))
-	})
-
-	It("should remove an active Pokemon when SetInactive is called", func() {
-		party.SetActive(0)
-		party.SetInactive(0)
-		Expect(party.GetActivePokemon()).To(HaveLen(0))
-	})
-
-	It("should add the active Pokemon the user expects", func() {
-		party.SetActive(1)
-		pkmn := party.GetActivePokemon()[1]
-		Expect(int(pkmn.NatDex)).To(Equal(9))
-	})
-
-	It("should panic when Pokemon should not change active state", func() {
-		Expect(func() {
-			party.SetInactive(0)
-		}).To(Panic())
-		party.SetActive(0)
-		Expect(func() {
-			party.SetActive(0)
-		}).To(Panic())
-	})
-
-	It("should panic when Pokemon does not exist", func() {
-		Expect(func() {
-			party.IsActivePokemon(7)
-		}).To(Panic())
-	})
-})
-
-var _ = Describe("Getting party Pokemon", func() {
-	var (
-		agent1 Agent
-		agent2 Agent
 		party1 *party
 		party2 *party
 		battle *Battle
 	)
 
 	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
 		party1 = NewOccupiedParty(&agent1, 0,
 			GeneratePokemon(PkmnCharmander),
 			GeneratePokemon(PkmnSquirtle),
@@ -364,19 +284,15 @@ var _ = Describe("Getting party Pokemon", func() {
 		battle.AddParty(party1, party2)
 	})
 
-	Context("Calling GetPokemon()", func() {
+	Context("when getting Pokemon by party/slot", func() {
 		It("should get the Pokemon the user expects", func() {
 			pkmn := battle.getPokemon(0, 1)
-			Expect(int(pkmn.NatDex)).To(Equal(7))
+			Expect(pkmn.NatDex).To(BeEquivalentTo(PkmnSquirtle))
 		})
 	})
 
-	Context("Getting ally Pokemon", func() {
-		It("should start the battle without error", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("should return targets whose team matches the passed party ", func() {
+	Context("when getting ally Pokemon", func() {
+		It("should return targets whose team matches the passed party", func() {
 			Expect(battle.Start()).To(Succeed())
 			for _, party := range []*party{party1, party2} {
 				allies := battle.GetAllies(party)
@@ -385,11 +301,7 @@ var _ = Describe("Getting party Pokemon", func() {
 		})
 	})
 
-	Context("Getting opposing Pokemon", func() {
-		It("should start the battle without error", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
-		})
+	Context("when getting opponent Pokemon", func() {
 		It("should return targets whose team does not match the passed party ", func() {
 			Expect(battle.Start()).To(Succeed())
 			for _, party := range []*party{party1, party2} {
@@ -400,98 +312,74 @@ var _ = Describe("Getting party Pokemon", func() {
 	})
 })
 
-var _ = Describe("Move priority", func() {
-	var (
-		a1 Agent
-		a2 Agent
-	)
+var _ = Describe("Turn priority", func() {
+	a1 := Agent(new(dumbAgent))
+	a2 := Agent(new(dumbAgent))
 
-	BeforeEach(func() {
-		a1 = Agent(dumbAgent{})
-		a2 = Agent(dumbAgent{})
-	})
-
-	Specify("Moves with higher priority should go first", func() {
-		p1 := GeneratePokemon(1, WithLevel(5), WithMoves(GetMove(MovePound)))
-		p1.Stats[StatSpeed] = 100
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(5), WithMoves(GetMove(MoveFakeOut)))
-		p2.Stats[StatSpeed] = 10
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		transactions, _ := b.SimulateRound()
-		Expect(transactions).To(HaveLen(2))
-		Expect(transactions).To(HaveTransactionsInOrder(
-			DamageTransaction{
-				User: p2,
-				Target: target{
-					Pokemon:   *p1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-				Damage: 5,
-				Move:   GetMove(MoveFakeOut),
-			},
-			DamageTransaction{
-				User: p1,
-				Target: target{
-					Pokemon:   *p2,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-				Damage: 5,
-				Move:   GetMove(MovePound),
-			},
-		))
-	})
-})
-
-var _ = Describe("Pokemon speed", func() {
-	var (
-		agent1     Agent
-		agent2     Agent
-		party1     *party
-		party2     *party
-		pound      *Move
-		battle     *Battle
-		charmander *Pokemon
-		ninjask    *Pokemon
-	)
-
-	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
-		pound = GetMove(MovePound)
-		charmander = GeneratePokemon(4, WithMoves(pound))
-		ninjask = GeneratePokemon(291, WithMoves(pound))
-		party1 = NewOccupiedParty(&agent1, 0, charmander)
-		party2 = NewOccupiedParty(&agent2, 1, ninjask) // ninjask is faster than charmander
-		battle = NewBattle()
-		battle.AddParty(party1, party2)
-		battle.SetSeed(1337)
-	})
-
-	Context("A faster Pokemon is fighting a slower one", func() {
-		It("should not error when starting", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
+	Context("each turn type should have a priority level", func() {
+		It("should have a priority of 0 for FightTurn", func() {
+			turn := FightTurn{}
+			Expect(turn.Priority()).To(Equal(0))
 		})
 
-		It("should create two transactions when simulating a round", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveLen(2))
+		It("should have a priority of 1 for ItemTurn", func() {
+			turn := ItemTurn{}
+			Expect(turn.Priority()).To(Equal(1))
+		})
+	})
+
+	Context("when determining priority for equal turn types", func() {
+		It("should handle moves with higher priority first", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(5), WithMoves(GetMove(MovePound)))
+			p1.Stats[StatSpeed] = 100
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnCharmander, WithLevel(5), WithMoves(GetMove(MoveFakeOut)))
+			p2.Stats[StatSpeed] = 10
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &SimpleRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveLen(2))
+			Expect(t).To(HaveTransactionsInOrder(
+				DamageTransaction{
+					User: p2,
+					Target: target{
+						Pokemon:   *p1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					Damage: 5,
+					Move:   GetMove(MoveFakeOut),
+				},
+				DamageTransaction{
+					User: p1,
+					Target: target{
+						Pokemon:   *p2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Damage: 5,
+					Move:   GetMove(MovePound),
+				},
+			))
 		})
 
-		Specify("faster Pokemon should go first", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveTransactionsInOrder(
+		It("should handle faster Pokemon first", func() {
+			pound := GetMove(MovePound)
+			charmander := GeneratePokemon(PkmnCharmander, WithMoves(pound))
+			ninjask := GeneratePokemon(PkmnNinjask, WithMoves(pound))
+			p1 := NewOccupiedParty(&a1, 0, charmander)
+			p2 := NewOccupiedParty(&a2, 1, ninjask) // ninjask is faster than charmander
+			b := NewBattle()
+			b.AddParty(p1, p2)
+			b.rng = &SimpleRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransactionsInOrder(
 				DamageTransaction{
 					User: ninjask,
 					Target: target{
@@ -519,58 +407,40 @@ var _ = Describe("Pokemon speed", func() {
 	})
 })
 
-var _ = Describe("Turn priority", func() {
-	Context("Fight turns", func() {
-		It("should have a priority of 0", func() {
-			turn := FightTurn{}
-			Expect(turn.Priority()).To(Equal(0))
-		})
-	})
-
-	Context("Item turns", func() {
-		It("should have a priority of 1", func() {
-			turn := ItemTurn{}
-			Expect(turn.Priority()).To(Equal(1))
-		})
-	})
-})
-
 var _ = Describe("Weather", func() {
+	a1 := Agent(new(dumbAgent))
+	a2 := Agent(new(dumbAgent))
 	var (
-		a1 Agent
-		a2 Agent
 		p1 *party
 		p2 *party
 		b  *Battle
 	)
 
 	BeforeEach(func() {
-		a1 = Agent(dumbAgent{})
-		a2 = Agent(dumbAgent{})
 		p1 = NewParty(&a1, 0)
 		p2 = NewParty(&a2, 1)
 		b = NewBattle()
 		b.AddParty(p1, p2)
-		b.SetSeed(1337)
+		b.rng = &SimpleRNG
 	})
 
-	Context("Weather should be caused by moves/abilities", func() {
+	Context("when using certain moves/certain abilities cause weather", func() {
 		// TODO: https://bulbapedia.bulbagarden.net/wiki/Weather#Causing_weather
-		It("should change to clear skies from defog", func() {
-			poke1 := GeneratePokemon(1, WithMoves(GetMove(MoveDefog)))
-			poke2 := GeneratePokemon(1, WithMoves(GetMove(MovePound)))
+		It("should clear fog when using MoveDefog", func() {
+			poke1 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveDefog)))
+			poke2 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MovePound)))
 			p1.AddPokemon(poke1)
 			p2.AddPokemon(poke2)
 			b.Weather = WeatherFog
 			Expect(b.Start()).To(Succeed())
-			transactions, _ := b.SimulateRound()
-			Expect(transactions).To(HaveTransaction(WeatherTransaction{
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(WeatherTransaction{
 				Weather: WeatherClearSkies,
 			}))
 		})
 	})
 
-	Context("Weather has effects in battle", func() {
+	Context("when weather is present, battles are affected", func() {
 		ember := GetMove(MoveEmber)
 		bubble := GetMove(MoveBubble)
 		tackle := GetMove(MoveTackle)
@@ -578,8 +448,8 @@ var _ = Describe("Weather", func() {
 		weatherBall := GetMove(MoveWeatherBall)
 		moonlight := GetMove(MoveMoonlight)
 		It("should affect fire/water attacks during harsh sunlight", func() {
-			charmander := GeneratePokemon(4, WithLevel(100), WithMoves(ember))
-			squirtle := GeneratePokemon(7, WithLevel(100), WithMoves(bubble))
+			charmander := GeneratePokemon(PkmnCharmander, WithLevel(100), WithMoves(ember))
+			squirtle := GeneratePokemon(PkmnSquirtle, WithLevel(100), WithMoves(bubble))
 			p1.AddPokemon(charmander)
 			p2.AddPokemon(squirtle)
 			b.Weather = WeatherHarshSunlight
@@ -615,8 +485,8 @@ var _ = Describe("Weather", func() {
 			))
 		})
 		It("should affect fire/water attacks during rain", func() {
-			charmander := GeneratePokemon(4, WithLevel(100), WithMoves(ember))
-			squirtle := GeneratePokemon(7, WithLevel(100), WithMoves(bubble))
+			charmander := GeneratePokemon(PkmnCharmander, WithLevel(100), WithMoves(ember))
+			squirtle := GeneratePokemon(PkmnSquirtle, WithLevel(100), WithMoves(bubble))
 			p1.AddPokemon(charmander)
 			p2.AddPokemon(squirtle)
 			b.Weather = WeatherRain
@@ -652,9 +522,9 @@ var _ = Describe("Weather", func() {
 			))
 		})
 		It("should damage/cause side effects during sandstorm", func() {
-			geodude := GeneratePokemon(74, WithLevel(50), WithMoves(tackle))
+			geodude := GeneratePokemon(PkmnGeodude, WithLevel(50), WithMoves(tackle))
 			geodude.Type = TypeRock | TypeGround
-			bulbasaur := GeneratePokemon(1, WithLevel(50), WithMoves(solarBeam))
+			bulbasaur := GeneratePokemon(PkmnBulbasaur, WithLevel(50), WithMoves(solarBeam))
 			p1.AddPokemon(geodude)
 			p2.AddPokemon(bulbasaur)
 			b.Weather = WeatherSandstorm
@@ -687,9 +557,9 @@ var _ = Describe("Weather", func() {
 			}))
 		})
 		It("should damage/cause side effects during hail", func() {
-			articuno := GeneratePokemon(144, WithMoves(tackle))
+			articuno := GeneratePokemon(PkmnArticuno, WithMoves(tackle))
 			articuno.Type = TypeIce
-			bulbasaur := GeneratePokemon(1, WithMoves(solarBeam))
+			bulbasaur := GeneratePokemon(PkmnBulbasaur, WithMoves(solarBeam))
 			p1.AddPokemon(articuno)
 			p2.AddPokemon(bulbasaur)
 			b.Weather = WeatherHail
@@ -722,20 +592,16 @@ var _ = Describe("Weather", func() {
 			}))
 		})
 		It("should cause side effects during fog", func() {
-			castform := GeneratePokemon(351, WithLevel(50), WithMoves(weatherBall))
-			bulbasaur := GeneratePokemon(1, WithLevel(50), WithMoves(solarBeam))
+			castform := GeneratePokemon(PkmnCastform, WithLevel(50), WithMoves(weatherBall))
+			bulbasaur := GeneratePokemon(PkmnBulbasaur, WithLevel(50), WithMoves(solarBeam))
 			p1.AddPokemon(castform)
 			p2.AddPokemon(bulbasaur)
 			b.Weather = WeatherFog
-			b.SetSeed(777777)
 			Expect(b.Start()).To(Succeed())
-			transactions, _ := b.SimulateRound()
-			// Accuracy decreases from fog
-			Expect(transactions).To(HaveTransaction(EvadeTransaction{
-				User: castform,
-			}))
+			t, _ := b.SimulateRound()
+			// TODO: Accuracy decreases from fog
 			// Solar beam weakened
-			Expect(transactions).To(HaveTransaction(DamageTransaction{
+			Expect(t).To(HaveTransaction(DamageTransaction{
 				User: bulbasaur,
 				Target: target{
 					Pokemon:   *castform,
@@ -747,17 +613,9 @@ var _ = Describe("Weather", func() {
 				Damage: 26,
 			}))
 			bulbasaur.Moves[0] = moonlight
-			transactions, _ = b.SimulateRound()
-			Expect(transactions).To(HaveTransaction(EvadeTransaction{
-				User: castform,
-			}))
+			t, _ = b.SimulateRound()
 			// Moonlight heals 1/4 max HP
-			Expect(transactions).To(HaveTransaction(HealTransaction{
-				Target: bulbasaur,
-				Amount: 26,
-			}))
-			transactions, _ = b.SimulateRound()
-			Expect(transactions).To(HaveTransaction(DamageTransaction{
+			Expect(t).To(HaveTransaction(DamageTransaction{
 				User: castform,
 				Target: target{
 					Pokemon:   *bulbasaur,
@@ -768,48 +626,41 @@ var _ = Describe("Weather", func() {
 				Move:   weatherBall,
 				Damage: 49,
 			}))
+			Expect(t).To(HaveTransaction(HealTransaction{
+				Target: bulbasaur,
+				Amount: 26,
+			}))
 		})
 	})
 })
 
 var _ = Describe("Fainting", func() {
+	a1 := Agent(new(dumbAgent))
+	a2 := Agent(new(dumbAgent))
 	var (
-		agent1 Agent
-		agent2 Agent
-		party1 *party
-		party2 *party
-		battle *Battle
+		p1 *party
+		p2 *party
+		b  *Battle
 	)
 
 	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
-		scary_monster := GeneratePokemon(7, WithLevel(100), WithMoves(GetMove(MovePound)))
+		scary_monster := GeneratePokemon(PkmnSquirtle, WithLevel(100), WithMoves(GetMove(MovePound)))
 		scary_monster.Stats[StatSpeed] = 1
-		party1 = NewOccupiedParty(&agent1, 0,
-			GeneratePokemon(4, WithMoves(GetMove(MovePound))),
-			GeneratePokemon(387, WithMoves(GetMove(MovePound))),
+		p1 = NewOccupiedParty(&a1, 0,
+			GeneratePokemon(PkmnCharmander, WithMoves(GetMove(MovePound))),
+			GeneratePokemon(PkmnTurtwig, WithMoves(GetMove(MovePound))),
 		)
-		party2 = NewOccupiedParty(&agent2, 1, scary_monster)
-		battle = NewBattle()
-		battle.AddParty(party1, party2)
-		battle.SetSeed(1337)
+		p2 = NewOccupiedParty(&a2, 1, scary_monster)
+		b = NewBattle()
+		b.AddParty(p1, p2)
+		b.rng = &SimpleRNG
 	})
 
-	Context("Switch is forced after a Pokemon faints", func() {
-		It("should start without error", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("causes 5 transactions to occur", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveLen(5))
-		})
-		It("should log all transactions as expected", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
+	Context("after a Pokemon faints in battle", func() {
+		It("should switch to the next available Pokemon", func() {
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveLen(5))
 			// Charmander smashed his nubby little fist into Squirtle as
 			// hard as he could. Spectators gasped and winced when the
 			// impact created a very audible crack. But it was not
@@ -820,193 +671,133 @@ var _ = Describe("Fainting", func() {
 			// Squirtle snarled, now covered in the entrails of his previous
 			// opponent. "OH GOD, WHAT THE FUCK!?" sobbed Ash, "Is my friend
 			// really gone forever? Please tell me I'm dreaming, this can't be real!"
-			Expect(transactions).To(HaveTransactionsInOrder(
+			Expect(t).To(HaveTransactionsInOrder(
 				FaintTransaction{
 					Target: target{
-						Pokemon:   *battle.parties[0].pokemon[0],
+						Pokemon:   *b.parties[0].pokemon[0],
 						party:     0,
 						partySlot: 0,
 						Team:      0,
 					},
 				}, SendOutTransaction{
 					Target: target{
-						Pokemon:   *battle.parties[0].pokemon[1],
+						Pokemon:   *b.parties[0].pokemon[1],
 						party:     0,
 						partySlot: 1,
 						Team:      0,
 					},
 				}))
 		})
-	})
 
-	Context("Fainting causes friendship to be lost", func() {
+		It("should not allow fainted Pokemon to take turns", func() {
+			party1 := NewParty(&a1, 0)
+			pkmn1 := GeneratePokemon(PkmnCharmander, WithLevel(3), WithMoves(GetMove(MovePound)))
+			pkmn2 := GeneratePokemon(PkmnSquirtle, WithLevel(10), WithMoves(GetMove(MovePound)))
+			pkmn3 := GeneratePokemon(PkmnTurtwig, WithLevel(3), WithMoves(GetMove(MovePound)))
+			pkmn1.CurrentHP = 1
+			party1.AddPokemon(pkmn1, pkmn3)
+			party2 := NewParty(&a2, 1)
+			pkmn2.Stats[StatSpeed] = 255
+			party2.AddPokemon(pkmn2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			Expect(b.Start()).To(Succeed())
+			t, ended := b.SimulateRound()
+			Expect(ended).To(BeFalse(), "Expected SimulateRound to NOT indicate that the battle has ended, but it did.")
+			Expect(t).To(HaveLen(4), "Expected 4 transactions to occur")
+			Expect(t).To(HaveTransactionsInOrder(
+				FaintTransaction{
+					Target: target{
+						Pokemon:   *pkmn1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+				},
+				SendOutTransaction{
+					Target: target{
+						Pokemon:   *pkmn3,
+						party:     0,
+						partySlot: 1,
+						Team:      0,
+					},
+				},
+			))
+			Expect(t).ToNot(HaveTransaction(
+				DamageTransaction{
+					User: pkmn1,
+					Target: target{
+						Pokemon:   *pkmn2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+				},
+			))
+		})
+
 		It("should lose 1 friendship when fainting", func() {
-			dies := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MovePound)))
+			dies := GeneratePokemon(PkmnBulbasaur, WithLevel(1), WithMoves(GetMove(MovePound)))
 			dies.Friendship = 100
-			p1 := NewOccupiedParty(&agent1, 0, dies)
-			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(25), WithMoves(GetMove(MovePound))))
-			battle = NewBattle()
-			battle.AddParty(p1, p2)
-			Expect(battle.Start()).To(Succeed())
-			battle.SimulateRound()
+			p1 := NewOccupiedParty(&a1, 0, dies)
+			p2 := NewOccupiedParty(&a2, 1, GeneratePokemon(PkmnCharmander, WithLevel(25), WithMoves(GetMove(MovePound))))
+			b = NewBattle()
+			b.AddParty(p1, p2)
+			Expect(b.Start()).To(Succeed())
+			b.SimulateRound()
 			Expect(dies.Friendship).To(Equal(99))
 		})
+
 		It("should lose 5 or 10 friendship when fainting", func() {
-			dies := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MovePound)))
+			dies := GeneratePokemon(PkmnBulbasaur, WithLevel(1), WithMoves(GetMove(MovePound)))
 			dies.Friendship = 100
-			dies2 := GeneratePokemon(1, WithLevel(1), WithMoves(GetMove(MovePound)))
+			dies2 := GeneratePokemon(PkmnBulbasaur, WithLevel(1), WithMoves(GetMove(MovePound)))
 			dies2.Friendship = 200
-			p1 := NewOccupiedParty(&agent1, 0, dies, dies2)
-			p2 := NewOccupiedParty(&agent2, 1, GeneratePokemon(4, WithLevel(100), WithMoves(GetMove(MovePound))))
-			battle = NewBattle()
-			battle.AddParty(p1, p2)
-			Expect(battle.Start()).To(Succeed())
-			battle.SimulateRound()
+			p1 := NewOccupiedParty(&a1, 0, dies, dies2)
+			p2 := NewOccupiedParty(&a2, 1, GeneratePokemon(PkmnCharmander, WithLevel(100), WithMoves(GetMove(MovePound))))
+			b = NewBattle()
+			b.AddParty(p1, p2)
+			Expect(b.Start()).To(Succeed())
+			b.SimulateRound()
 			Expect(dies.Friendship).To(Equal(95))
-			battle.SimulateRound()
+			b.SimulateRound()
 			Expect(dies2.Friendship).To(Equal(190))
 		})
 	})
-
-	Specify("Dead pokemon should not take turns", func() {
-		a1 := Agent(dumbAgent{})
-		a2 := Agent(dumbAgent{})
-		party1 := NewParty(&a1, 0)
-		pkmn1 := GeneratePokemon(4, WithLevel(3), WithMoves(GetMove(MovePound)))
-		pkmn1.CurrentHP = 1
-		party1.AddPokemon(pkmn1)
-		party2 := NewParty(&a2, 1)
-		pkmn2 := GeneratePokemon(7, WithLevel(10), WithMoves(GetMove(MovePound)))
-		pkmn2.Stats[StatSpeed] = 255
-		party2.AddPokemon(pkmn2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		transactions, ended := b.SimulateRound()
-		Expect(ended).To(BeTrue(), "Expected SimulateRound to indicate that the battle has ended, but it did not.")
-		Expect(transactions).To(HaveLen(4))
-		Expect(transactions).To(HaveTransactionsInOrder(
-			FaintTransaction{
-				Target: target{
-					Pokemon:   *pkmn1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-			},
-			EndBattleTransaction{},
-		))
-		Expect(transactions).ToNot(HaveTransaction(
-			DamageTransaction{
-				User: pkmn1,
-				Target: target{
-					Pokemon:   *pkmn2,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-			},
-		))
-	})
-
-	Specify("Dead pokemon should not take turns", func() {
-		a1 := Agent(dumbAgent{})
-		a2 := Agent(dumbAgent{})
-		party1 := NewParty(&a1, 0)
-		pkmn1 := GeneratePokemon(4, WithLevel(3), WithMoves(GetMove(MovePound)))
-		pkmn2 := GeneratePokemon(7, WithLevel(10), WithMoves(GetMove(MovePound)))
-		pkmn3 := GeneratePokemon(387, WithLevel(3), WithMoves(GetMove(MovePound)))
-		pkmn1.CurrentHP = 1
-		party1.AddPokemon(pkmn1, pkmn3)
-		party2 := NewParty(&a2, 1)
-		pkmn2.Stats[StatSpeed] = 255
-		party2.AddPokemon(pkmn2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		t, ended := b.SimulateRound()
-		Expect(ended).To(BeFalse(), "Expected SimulateRound to NOT indicate that the battle has ended, but it did.")
-		Expect(t).To(HaveLen(4), "Expected 4 transactions to occur")
-		Expect(t).To(HaveTransactionsInOrder(
-			FaintTransaction{
-				Target: target{
-					Pokemon:   *pkmn1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-			},
-			SendOutTransaction{
-				Target: target{
-					Pokemon:   *pkmn3,
-					party:     0,
-					partySlot: 1,
-					Team:      0,
-				},
-			},
-		))
-		Expect(t).ToNot(HaveTransaction(
-			DamageTransaction{
-				User: pkmn1,
-				Target: target{
-					Pokemon:   *pkmn2,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-			},
-		))
-	})
 })
 
-var _ = Describe("Ending a battle", func() {
+var _ = Describe("Battle end", func() {
+	a1 := Agent(new(dumbAgent))
+	a2 := Agent(new(dumbAgent))
 	var (
-		agent1 Agent
-		agent2 Agent
-		party1 *party
-		party2 *party
-		battle *Battle
+		b     *Battle
+		pkmn1 *Pokemon
+		pkmn2 *Pokemon
 	)
 
 	BeforeEach(func() {
-		agent1 = Agent(dumbAgent{})
-		agent2 = Agent(dumbAgent{})
-		low_health_pkmn := GeneratePokemon(4, WithMoves(GetMove(MovePound)))
-		low_health_pkmn.CurrentHP = 1
-		party1 = NewOccupiedParty(&agent1, 0, low_health_pkmn)
-		party2 = NewOccupiedParty(&agent2, 1, GeneratePokemon(7, WithMoves(GetMove(MovePound))))
-		battle = NewBattle()
-		battle.AddParty(party1, party2)
-		battle.SetSeed(1337)
+		party1 := NewParty(&a1, 0)
+		pkmn1 = GeneratePokemon(PkmnCharmander, WithLevel(3), WithMoves(GetMove(MovePound)))
+		pkmn1.CurrentHP = 1
+		party1.AddPokemon(pkmn1)
+		party2 := NewParty(&a2, 1)
+		pkmn2 = GeneratePokemon(PkmnSquirtle, WithLevel(10), WithMoves(GetMove(MovePound)))
+		pkmn2.Stats[StatSpeed] = 255
+		party2.AddPokemon(pkmn2)
+		b = NewBattle()
+		b.AddParty(party1, party2)
 	})
 
-	Context("Battle ends by knockout", func() {
-		It("should start without error", func() {
-			err := battle.Start()
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("should end", func() {
-			Expect(battle.Start()).To(Succeed())
-			_, ended := battle.SimulateRound()
-			Expect(ended).To(BeTrue())
-		})
-
-		It("should have 5 transactions occur", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveLen(5))
-		})
-
-		It("should log all transaction correctly", func() {
-			Expect(battle.Start()).To(Succeed())
-			transactions, _ := battle.SimulateRound()
-			Expect(transactions).To(HaveTransactionsInOrder(
+	Context("when all Pokemon faint on one team", func() {
+		It("should end the battle", func() {
+			Expect(b.Start()).To(Succeed())
+			t, ended := b.SimulateRound()
+			Expect(ended).To(BeTrue(), "Expected SimulateRound to indicate that the battle has ended, but it did not.")
+			Expect(t).To(HaveLen(4))
+			Expect(t).To(HaveTransactionsInOrder(
 				FaintTransaction{
 					Target: target{
-						Pokemon:   *battle.parties[0].pokemon[0],
+						Pokemon:   *pkmn1,
 						party:     0,
 						partySlot: 0,
 						Team:      0,
@@ -1014,193 +805,187 @@ var _ = Describe("Ending a battle", func() {
 				},
 				EndBattleTransaction{},
 			))
+			Expect(t).ToNot(HaveTransaction(
+				DamageTransaction{
+					User: pkmn1,
+					Target: target{
+						Pokemon:   *pkmn2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+				},
+			))
 		})
 	})
 })
 
 var _ = Describe("Status Conditions", func() {
-	var (
-		a1 Agent
-		a2 Agent
-	)
+	a1 := Agent(new(dumbAgent))
+	a2 := Agent(new(dumbAgent))
 
-	BeforeEach(func() {
-		a1 = Agent(dumbAgent{})
-		a2 = Agent(dumbAgent{})
-	})
-
-	It("should cause status effects from moves", func() {
-		p1 := GeneratePokemon(1, WithMoves(GetMove(MoveSplash)))
-		p2 := GeneratePokemon(1, WithMoves(GetMove(MoveStunSpore)))
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.rng = &AlwaysRNG
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveTransaction(
-			InflictStatusTransaction{
-				Target:       p1,
-				StatusEffect: StatusParalyze,
-			},
-		))
-	})
-
-	It("should inflict burn and poison damage", func() {
-		p1 := GeneratePokemon(1, WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusPoison
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(2, WithMoves(GetMove(MovePound)))
-		p2.StatusEffects = StatusBurn
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveLen(4), "Expected only 4 transactions to occur in a round")
-		Expect(t).To(HaveTransaction(DamageTransaction{
-			Target: target{
-				Pokemon:   *p1,
-				party:     0,
-				partySlot: 0,
-				Team:      0,
-			},
-			Damage:       1,
-			StatusEffect: StatusPoison,
-		}))
-		Expect(t).To(HaveTransaction(DamageTransaction{
-			Target: target{
-				Pokemon:   *p2,
-				party:     1,
-				partySlot: 0,
-				Team:      1,
-			},
-			Damage:       1,
-			StatusEffect: StatusBurn,
-		}))
-	})
-
-	It("should inflict badly poisoned damage", func() {
-		p1 := GeneratePokemon(1, WithLevel(100), WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusBadlyPoison
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(2, WithLevel(100), WithMoves(GetMove(MovePound)))
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveLen(3), "Expected only 3 transactions to occur in a round")
-		Expect(t).To(HaveTransaction(DamageTransaction{
-			Target: target{
-				Pokemon:   *p1,
-				party:     0,
-				partySlot: 0,
-				Team:      0,
-			},
-			Damage:       12,
-			StatusEffect: StatusBadlyPoison,
-		}))
-	})
-
-	Specify("Paralysis", func() {
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusParalyze
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MovePound)))
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1)
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveTransaction(
-			ImmobilizeTransaction{
-				Target: target{
-					Pokemon:   *p1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
+	Context("when using certain moves in battle causes status effects", func() {
+		It("should inflict paralysis from MoveStunSpore", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveSplash)))
+			p2 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveStunSpore)))
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &AlwaysRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(
+				InflictStatusTransaction{
+					Target:       p1,
+					StatusEffect: StatusParalyze,
 				},
-				StatusEffect: StatusParalyze,
-			},
-		))
-	})
-
-	Specify("Freeze", func() {
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusFreeze
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MovePound)))
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(34987)
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveTransaction(
-			ImmobilizeTransaction{
-				Target: target{
-					Pokemon:   *p1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-				StatusEffect: StatusFreeze,
-			},
-		))
-	})
-
-	Specify("Sleep", func() {
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusSleep
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MovePound)))
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveTransaction(
-			ImmobilizeTransaction{
-				Target: target{
-					Pokemon:   *p1,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-				StatusEffect: StatusSleep,
-			},
-		))
-	})
-
-	It("Should cure paralysis", func() {
-		p1 := GeneratePokemon(1, WithLevel(8), WithMoves(GetMove(MovePound)))
-		p1.StatusEffects = StatusParalyze
-		party1 := NewOccupiedParty(&a1, 0, p1)
-		p2 := GeneratePokemon(4, WithLevel(4), WithMoves(GetMove(MovePound)))
-		party2 := NewOccupiedParty(&a2, 1, p2)
-		b := NewBattle()
-		b.AddParty(party1, party2)
-		b.SetSeed(1337)
-		Expect(b.Start()).To(Succeed())
-		b.QueueTransaction(CureStatusTransaction{
-			Target: target{
-				Pokemon:   *p1,
-				party:     0,
-				partySlot: 0,
-				Team:      0,
-			},
-			StatusEffect: StatusParalyze,
+			))
 		})
-		b.ProcessQueue()
-		t, _ := b.SimulateRound()
-		Expect(t).To(HaveTransaction(
-			CureStatusTransaction{
+	})
+
+	Context("when a Pokemon has a status effect, it affects the Pokemon in battle", func() {
+		It("should inflict burn and poison damage", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusPoison
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnIvysaur, WithMoves(GetMove(MovePound)))
+			p2.StatusEffects = StatusBurn
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.SetSeed(1337)
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveLen(4), "Expected only 4 transactions to occur in a round")
+			Expect(t).To(HaveTransaction(DamageTransaction{
+				Target: target{
+					Pokemon:   *p1,
+					party:     0,
+					partySlot: 0,
+					Team:      0,
+				},
+				Damage:       1,
+				StatusEffect: StatusPoison,
+			}))
+			Expect(t).To(HaveTransaction(DamageTransaction{
+				Target: target{
+					Pokemon:   *p2,
+					party:     1,
+					partySlot: 0,
+					Team:      1,
+				},
+				Damage:       1,
+				StatusEffect: StatusBurn,
+			}))
+		})
+
+		It("should inflict badly poisoned damage", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(100), WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusBadlyPoison
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnIvysaur, WithLevel(100), WithMoves(GetMove(MovePound)))
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &AlwaysRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveLen(3), "Expected only 3 transactions to occur in a round")
+			Expect(t).To(HaveTransaction(DamageTransaction{
+				Target: target{
+					Pokemon:   *p1,
+					party:     0,
+					partySlot: 0,
+					Team:      0,
+				},
+				Damage:       12,
+				StatusEffect: StatusBadlyPoison,
+			}))
+		})
+
+		It("should immobilize paralyzed Pokemon", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(8), WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusParalyze
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnCharmander, WithLevel(4), WithMoves(GetMove(MovePound)))
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &AlwaysRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(
+				ImmobilizeTransaction{
+					Target: target{
+						Pokemon:   *p1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					StatusEffect: StatusParalyze,
+				},
+			))
+		})
+
+		It("should immobilize frozen Pokemon", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(8), WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusFreeze
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnCharmander, WithLevel(4), WithMoves(GetMove(MovePound)))
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &AlwaysRNG
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(
+				ImmobilizeTransaction{
+					Target: target{
+						Pokemon:   *p1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					StatusEffect: StatusFreeze,
+				},
+			))
+		})
+
+		It("should immobilize sleeping Pokemon", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(8), WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusSleep
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnCharmander, WithLevel(4), WithMoves(GetMove(MovePound)))
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.SetSeed(1337)
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(
+				ImmobilizeTransaction{
+					Target: target{
+						Pokemon:   *p1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					StatusEffect: StatusSleep,
+				},
+			))
+		})
+
+		It("should cure paralysis", func() {
+			p1 := GeneratePokemon(PkmnBulbasaur, WithLevel(8), WithMoves(GetMove(MovePound)))
+			p1.StatusEffects = StatusParalyze
+			party1 := NewOccupiedParty(&a1, 0, p1)
+			p2 := GeneratePokemon(PkmnCharmander, WithLevel(4), WithMoves(GetMove(MovePound)))
+			party2 := NewOccupiedParty(&a2, 1, p2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			Expect(b.Start()).To(Succeed())
+			b.QueueTransaction(CureStatusTransaction{
 				Target: target{
 					Pokemon:   *p1,
 					party:     0,
@@ -1208,7 +993,20 @@ var _ = Describe("Status Conditions", func() {
 					Team:      0,
 				},
 				StatusEffect: StatusParalyze,
-			},
-		))
+			})
+			b.ProcessQueue()
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(
+				CureStatusTransaction{
+					Target: target{
+						Pokemon:   *p1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					StatusEffect: StatusParalyze,
+				},
+			))
+		})
 	})
 })

--- a/battle_test.go
+++ b/battle_test.go
@@ -326,6 +326,35 @@ var _ = Describe("Turn priority", func() {
 			turn := ItemTurn{}
 			Expect(turn.Priority()).To(Equal(1))
 		})
+
+		It("should order turns properly based on priority", func() {
+			a2 := Agent(new(healAgent))
+			bulbasaur := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MovePound)))
+			charmander := GeneratePokemon(PkmnCharmander, WithMoves(GetMove(MovePound)))
+			p1 := NewOccupiedParty(&a1, 0, bulbasaur)
+			p2 := NewOccupiedParty(&a2, 1, charmander)
+			b := NewBattle()
+			b.AddParty(p1, p2)
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransactionsInOrder(
+				HealTransaction{
+					Target: charmander,
+					Amount: 0,
+				},
+				DamageTransaction{
+					User: bulbasaur,
+					Target: target{
+						Pokemon:   *charmander,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Move:   GetMove(MovePound),
+					Damage: 3,
+				},
+			))
+		})
 	})
 
 	Context("when determining priority for equal turn types", func() {

--- a/party_test.go
+++ b/party_test.go
@@ -1,0 +1,65 @@
+package pokemonbattlelib
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Party creation", func() {
+	agent := Agent(new(dumbAgent))
+
+	Context("when adding Pokemon to a party", func() {
+		It("panics when adding too many Pokemon to a party", func() {
+			party := NewParty(&agent, 0)
+			for i := 0; i < MaxPartySize; i += 1 {
+				party.AddPokemon(GeneratePokemon(PkmnBulbasaur))
+			}
+			Expect(func() {
+				party.AddPokemon(GeneratePokemon(PkmnBulbasaur))
+			}).To(Panic())
+		})
+	})
+})
+
+var _ = Describe("Active pokemon", func() {
+	agent := Agent(new(dumbAgent))
+	var (
+		party *party
+	)
+
+	BeforeEach(func() {
+		party = NewOccupiedParty(&agent, 0, GeneratePokemon(PkmnSquirtle), GeneratePokemon(PkmnBlastoise))
+	})
+
+	Context("when managing active Pokemon in a party", func() {
+		It("should correctly add an active Pokemon", func() {
+			party.SetActive(0)
+			Expect(party.GetActivePokemon()).To(HaveLen(1))
+			Expect(party.activePokemon[0].NatDex).To(BeEquivalentTo(PkmnSquirtle))
+			party.SetActive(1)
+			Expect(party.activePokemon[1].NatDex).To(BeEquivalentTo(PkmnBlastoise))
+		})
+
+		It("should remove an active Pokemon", func() {
+			party.SetActive(0)
+			party.SetInactive(0)
+			Expect(party.GetActivePokemon()).To(HaveLen(0))
+		})
+
+		It("should panic when Pokemon should not change active state", func() {
+			Expect(func() {
+				party.SetInactive(0)
+			}).To(Panic())
+			party.SetActive(0)
+			Expect(func() {
+				party.SetActive(0)
+			}).To(Panic())
+		})
+
+		It("should panic when Pokemon does not exist", func() {
+			Expect(func() {
+				party.IsActivePokemon(7)
+			}).To(Panic())
+		})
+	})
+})

--- a/pokemon_test.go
+++ b/pokemon_test.go
@@ -128,42 +128,42 @@ var _ = Describe("Pokemon generation", func() {
 	})
 
 	It("panics when trying to create a Pokemon out of level bounds", func() {
-		Expect(func() { GeneratePokemon(396, WithLevel(MaxLevel+1)) }).To(Panic())
-		Expect(func() { GeneratePokemon(396, WithLevel(MinLevel-1)) }).To(Panic())
+		Expect(func() { GeneratePokemon(PkmnStarly, WithLevel(MaxLevel+1)) }).To(Panic())
+		Expect(func() { GeneratePokemon(PkmnStarly, WithLevel(MinLevel-1)) }).To(Panic())
 	})
 
 	It("panics when creating a Pokemon with higher than max IVs", func() {
-		Expect(func() { GeneratePokemon(396, WithIVs([6]uint8{32, 32, 32, 32, 32, 32})) }).To(Panic())
+		Expect(func() { GeneratePokemon(PkmnStarly, WithIVs([6]uint8{32, 32, 32, 32, 32, 32})) }).To(Panic())
 	})
 
 	It("panics when creating a Pokemon with higher than max EVs", func() {
-		Expect(func() { GeneratePokemon(396, WithEVs([6]uint8{255, 255, 255, 255, 255, 255})) }).To(Panic())
+		Expect(func() { GeneratePokemon(PkmnStarly, WithEVs([6]uint8{255, 255, 255, 255, 255, 255})) }).To(Panic())
 	})
 
 	It("panics when creating a Pokemon with more than the maximum allowed moves", func() {
 		pound := GetMove(MovePound)
-		Expect(func() { GeneratePokemon(396, WithMoves(pound, pound, pound, pound, pound)) }).To(Panic())
+		Expect(func() { GeneratePokemon(PkmnStarly, WithMoves(pound, pound, pound, pound, pound)) }).To(Panic())
 	})
 })
 
 var _ = Describe("Test leveling methods", func() {
 	It("panics when leveling beyond the max level", func() {
-		pkmn := GeneratePokemon(6, WithLevel(MaxLevel))
+		pkmn := GeneratePokemon(PkmnCharizard, WithLevel(MaxLevel))
 		Expect(func() { pkmn.GainLevels(1) }).To(Panic())
 	})
 
 	It("panics when trying to level down", func() {
-		pkmn := GeneratePokemon(393, WithLevel(5))
+		pkmn := GeneratePokemon(PkmnPiplup, WithLevel(5))
 		Expect(func() { pkmn.GainLevels(-1) }).To(Panic())
 	})
 
 	It("panics when trying to lose experience", func() {
-		pkmn := GeneratePokemon(393, WithLevel(5))
+		pkmn := GeneratePokemon(PkmnPiplup, WithLevel(5))
 		Expect(func() { pkmn.GainExperience(-135) }).To(Panic())
 	})
 
 	It("prevents a Pokemon from gaining experience beyond the max", func() {
-		pkmn := GeneratePokemon(493, WithLevel(MaxLevel))
+		pkmn := GeneratePokemon(PkmnArceus, WithLevel(MaxLevel))
 		pkmn.GainExperience(100000000000)
 		Expect(int(pkmn.Level)).To(Equal(MaxLevel))
 	})
@@ -176,7 +176,7 @@ var _ = Describe("Stringer interface", func() {
 	)
 
 	It("prints as expected", func() {
-		pkmn = GeneratePokemon(1, WithLevel(5))
+		pkmn = GeneratePokemon(PkmnBulbasaur, WithLevel(5))
 		pkmn.Gender = GenderFemale
 		want = "Bulbasaur♀\tLv5\nHP: 19/19\n"
 		Expect(fmt.Sprintf("%s", pkmn)).To(Equal(want))


### PR DESCRIPTION
The goal of this PR is to establish a pattern in our test files, and properly scope current tests. Many tests were repeatedly testing the same functionality, so I tried to consolidate this as much as possible without taking away from the integrity of the test. Here are some of the main changes:

- Moved all agent creation outside of `BeforeEach`, as it doesn't need to be there
- Added constants (mostly Pokemon names) where applicable
- Removed redundant tests (e.g. crit chance checking if battle.Start didn't error)
- Combined certain test groups (turn priority/pokemon speed/move priority are now under the umbrella of turn priority)
- Moved logic testing parties to `party_test.go`
- Replaced occurrences of `b.SetSeed` to `b.rng = ...`
- nit: shortened variable names (agent1 -> a1, transactions -> t)

Some of this is subjective and I understand that. But with this I was able to reduce the number of tests by some 20%, shortened the file a little bit, and hopefully made it more clear how tests can be structured with Gomega. I think with #148, there is more opportunity to simplify these tests, especially with party/battle reuse.