### PR TITLE
feat(battle): add battle.metadata, MetaWeatherTurns + MoveSunnyDay

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -387,7 +387,6 @@ func (b *Battle) postRound() {
 					})
 				}
 			}
-
 			if pkmn.HeldItem != nil && pkmn.HeldItem.Category == ItemCategoryInAPinch && pkmn.CurrentHP <= pkmn.Stats[StatHP]/4 {
 				b.QueueTransaction(ItemTransaction{
 					Target: pkmn,
@@ -395,6 +394,16 @@ func (b *Battle) postRound() {
 				})
 			}
 		}
+	}
+	// Effects on the battle
+	// Decrease weather counter/clear weather over time
+	if b.Weather != WeatherClearSkies && b.metadata[MetaWeatherTurns] == 0 {
+		b.QueueTransaction(WeatherTransaction{
+			Weather: WeatherClearSkies,
+		})
+	}
+	if turns := b.metadata[MetaWeatherTurns].(int); turns > 0 {
+		b.metadata[MetaWeatherTurns] = turns - 1
 	}
 }
 

--- a/battle.go
+++ b/battle.go
@@ -14,11 +14,18 @@ type Battle struct {
 	State    BattleState
 	rng      RNG
 
-	parties []*party // All parties participating in the battle
+	parties  []*party                   // All parties participating in the battle
+	metadata map[BattleMeta]interface{} // Metadata to be tracked during a battle
 
 	tQueue     []Transaction
 	tProcessed []Transaction
 }
+
+type BattleMeta int
+
+const (
+	MetaWeatherTurns BattleMeta = iota
+)
 
 type BattleState int
 
@@ -34,6 +41,9 @@ func NewBattle() *Battle {
 	b := Battle{
 		State: BattleBeforeStart,
 		rng:   RNG(&rng),
+		metadata: map[BattleMeta]interface{}{
+			MetaWeatherTurns: 0,
+		},
 	}
 	return &b
 }
@@ -220,6 +230,11 @@ func (b *Battle) SimulateRound() ([]Transaction, bool) {
 							Amount: -4,
 						})
 					}
+				case MoveSunnyDay:
+					b.QueueTransaction(WeatherTransaction{
+						Weather: WeatherHarshSunlight,
+						Turns:   5,
+					})
 				case MoveHowl:
 					b.QueueTransaction(ModifyStatTransaction{
 						Target: &user,

--- a/battle_test.go
+++ b/battle_test.go
@@ -470,16 +470,27 @@ var _ = Describe("Weather", func() {
 	Context("when using certain moves/certain abilities cause weather", func() {
 		// TODO: https://bulbapedia.bulbagarden.net/wiki/Weather#Causing_weather
 		It("should clear fog when using MoveDefog", func() {
-			poke1 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveDefog)))
-			poke2 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MovePound)))
-			p1.AddPokemon(poke1)
-			p2.AddPokemon(poke2)
+			pkmn1 := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveDefog)))
+			pkmn2 := GeneratePokemon(PkmnMagikarp, WithMoves(GetMove(MoveSplash)))
+			p1.AddPokemon(pkmn1)
+			p2.AddPokemon(pkmn2)
 			b.Weather = WeatherFog
 			Expect(b.Start()).To(Succeed())
 			t, _ := b.SimulateRound()
 			Expect(t).To(HaveTransaction(WeatherTransaction{
 				Weather: WeatherClearSkies,
 			}))
+		})
+		It("should cause harsh sunlight", func() {
+			p1.AddPokemon(GeneratePokemon(PkmnCharmander, WithMoves(GetMove(MoveSunnyDay))))
+			p2.AddPokemon(GeneratePokemon(PkmnMagikarp, WithMoves(GetMove(MoveSplash))))
+			Expect(b.Start()).To(Succeed())
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(WeatherTransaction{
+				Weather: WeatherHarshSunlight,
+				Turns:   5,
+			}))
+			Expect(b.metadata[MetaWeatherTurns]).To(Equal(5))
 		})
 	})
 
@@ -1124,7 +1135,7 @@ var _ = Describe("In-a-pinch Berries", func() {
 		b := NewBattle()
 		b.rng = &SimpleRNG
 		b.AddParty(p1, p2)
-		b.Start()
+		Expect(b.Start()).To(Succeed())
 		return b
 	}
 

--- a/transactions.go
+++ b/transactions.go
@@ -191,10 +191,12 @@ func (t SendOutTransaction) Mutate(b *Battle) {
 // Changes the current weather in a battle
 type WeatherTransaction struct {
 	Weather Weather
+	Turns   int
 }
 
 func (t WeatherTransaction) Mutate(b *Battle) {
 	b.Weather = t.Weather
+	b.metadata[MetaWeatherTurns] = t.Turns
 }
 
 // A transaction that ends the battle.


### PR DESCRIPTION
With #194 adding metadata to Pokemon, this should close #135. Cases that are not applicable to `battle.metadata` or `Pokemon.metadata` should be a new issue.

This PR uses the number of turns for weather in battle as an example. Closes #214.