### PR TITLE
fix: change Pokemon.HeldItem to be an ID (int)

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -400,11 +400,13 @@ func (b *Battle) postRound() {
 					})
 				}
 			}
-			if pkmn.HeldItem != nil && pkmn.HeldItem.Category == ItemCategoryInAPinch && pkmn.CurrentHP <= pkmn.Stats[StatHP]/4 {
-				b.QueueTransaction(ItemTransaction{
-					Target: pkmn,
-					Item:   pkmn.HeldItem,
-				})
+			if pkmn.HeldItem != 0 && pkmn.CurrentHP <= pkmn.Stats[StatHP]/4 {
+				if i := GetItem(pkmn.HeldItem); i.Category == ItemCategoryInAPinch {
+					b.QueueTransaction(ItemTransaction{
+						Target: pkmn,
+						Item:   i,
+					})
+				}
 			}
 		}
 	}
@@ -517,7 +519,7 @@ func (turn FightTurn) Priority() int {
 type ItemTurn struct {
 	Move   int    // Denotes the index (0-3) of the pokemon's which of the pokemon's moves to use.
 	Target target // Info containing data determining the target of
-	Item   *Item  // Which item is being consumed
+	Item   Item   // Which item is being consumed
 }
 
 func (turn ItemTurn) Priority() int {

--- a/battle_test.go
+++ b/battle_test.go
@@ -27,7 +27,7 @@ func (a healAgent) Act(ctx *BattleContext) Turn {
 	item := GetItem(ItemPotion)
 	for _, target := range ctx.Allies {
 		return ItemTurn{
-			Item:   &item,
+			Item:   item,
 			Target: target,
 		}
 	}
@@ -263,7 +263,7 @@ var _ = Describe("Using items in battle", func() {
 			Expect(t).To(HaveTransaction(
 				ItemTransaction{
 					Target: pkmn,
-					Item:   &potion,
+					Item:   potion,
 					Move:   nil,
 				},
 			))
@@ -1214,8 +1214,7 @@ var _ = Describe("In-a-pinch Berries", func() {
 			WithMoves(GetMove(MoveSplash)),
 			WithIVs([6]uint8{1, 1, 1, 20, 1, 1}),
 		)
-		i := GetItem(itemId)
-		holder.HeldItem = &i
+		holder.HeldItem = itemId
 		holder.CurrentHP = holder.MaxHP() / 4
 		p2 := NewOccupiedParty(&a2, 1, holder)
 		b := NewBattle()
@@ -1229,10 +1228,9 @@ var _ = Describe("In-a-pinch Berries", func() {
 		func(item, stat, stages int) {
 			b := setup(item)
 			t, _ := b.SimulateRound()
-
 			Expect(t).To(HaveTransaction(ItemTransaction{
 				Target: holder,
-				Item:   holder.HeldItem,
+				Item:   GetItem(item),
 			}))
 			Expect(t).To(HaveTransaction(ModifyStatTransaction{
 				Target: holder,

--- a/items.go
+++ b/items.go
@@ -105,7 +105,7 @@ func GetItem(itemID int) Item {
 }
 
 // Dispatches the correct item handler based on its category
-func (p *Pokemon) UseItem(i *Item) []Transaction {
+func (p *Pokemon) UseItem(i Item) []Transaction {
 	switch i.Category {
 	case ItemCategoryHealing, ItemCategoryRevival, ItemCategoryStatusCures:
 		return p.UseMedicine(i)
@@ -116,7 +116,7 @@ func (p *Pokemon) UseItem(i *Item) []Transaction {
 }
 
 // Uses a medicine item which affects HP and status effects
-func (p *Pokemon) UseMedicine(i *Item) (t []Transaction) {
+func (p *Pokemon) UseMedicine(i Item) (t []Transaction) {
 	switch i.ID {
 	case ItemPotion:
 		t = append(t, p.RestoreHP(20))
@@ -124,7 +124,7 @@ func (p *Pokemon) UseMedicine(i *Item) (t []Transaction) {
 	return t
 }
 
-func (p *Pokemon) UseBerryInAPinch(i *Item) (t []Transaction) {
+func (p *Pokemon) UseBerryInAPinch(i Item) (t []Transaction) {
 	switch i.ID {
 	case ItemApicotBerry:
 		t = append(t, ModifyStatTransaction{

--- a/items_test.go
+++ b/items_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Using items", func() {
 		i := GetItem(ItemPotion)
 		p := GeneratePokemon(PkmnBulbasaur)
 		p.Stats[StatHP] = 100
-		t := p.UseItem(&i)
+		t := p.UseItem(i)
 		Expect(t).To(HaveTransaction(
 			HealTransaction{
 				Target: p,

--- a/pokemon.go
+++ b/pokemon.go
@@ -22,7 +22,7 @@ type Pokemon struct {
 	StatModifiers     [9]int                      // ranges from +6 (buffing) to -6 (debuffing) a stat
 	StatusEffects     StatusCondition             // the current status effects inflicted on a Pokemon
 	CurrentHP         uint                        // the remaining HP of this Pokemon
-	HeldItem          *Item                       // the item a Pokemon is holding
+	HeldItem          int                         // the ID (or 0) of the item a Pokemon is holding
 	Moves             [MaxMoves]*Move             // the moves the Pokemon currenly knows
 	Friendship        int                         // how close this Pokemon is to its Trainer
 	OriginalTrainerID uint16                      // a number associated with the first Trainer who caught this Pokemon

--- a/transactions.go
+++ b/transactions.go
@@ -88,14 +88,14 @@ func (t EVTransaction) Mutate(b *Battle) {
 // A transaction to use and possibly consume an item.
 type ItemTransaction struct {
 	Target *Pokemon
-	Item   *Item
+	Item   Item
 	Move   *Move
 }
 
 func (t ItemTransaction) Mutate(b *Battle) {
 	if t.Item.Flags&FlagConsumable > 0 {
-		if t.Target.HeldItem == t.Item {
-			t.Target.HeldItem = nil
+		if t.Target.HeldItem == t.Item.ID {
+			t.Target.HeldItem = 0
 		}
 		// TODO: remove consumed item from party's inventory
 	}


### PR DESCRIPTION
This doesn't really add syntactic sugar if you need any other properties of an item, such as the category in this example:

```go
if pkmn.HeldItem != 0 && pkmn.CurrentHP <= pkmn.Stats[StatHP]/4 {
	if i := GetItem(pkmn.HeldItem); i.Category == ItemCategoryInAPinch {
		b.QueueTransaction(ItemTransaction{
			Target: pkmn,
			Item:   i,
		})
	}
}
```