### PR TITLE
simulate refactor

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -183,7 +183,7 @@ var _ = Describe("One round of battle", func() {
 			battle.rng = &AlwaysRNG
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(4))
+			Expect(squirtle.CurrentHP).To(BeEquivalentTo(5))
 		})
 
 		It("should miss moves randomly based on accuracy/evasion", func() {

--- a/calc.go
+++ b/calc.go
@@ -1,0 +1,50 @@
+package pokemonbattlelib
+
+func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damage uint) {
+	weatherMod := 1.0
+	if rain, sun := weather == WeatherRain, weather == WeatherHarshSunlight; (rain && move.Type() == TypeWater) || (sun && move.Type() == TypeFire) {
+		weatherMod = 1.5
+	} else if (rain && move.Type() == TypeFire) || (sun && move.Type() == TypeWater) {
+		weatherMod = 0.5
+	}
+
+	stab := 1.0
+	if move != nil && user.Type&move.Type() != 0 {
+		stab = 1.5
+		if user.Ability != nil && user.Ability.ID == 91 { // Adaptability
+			stab = 2.0
+		}
+	}
+
+	modifier := weatherMod * stab
+	levelEffect := float64((2 * user.Level / 5) + 2)
+	movePower := float64(move.Power())
+	attack := float64(user.Attack())
+	defense := float64(receiver.Defense())
+	// Move modifiers
+	if move.Category() == MoveCategorySpecial {
+		attack = float64(user.SpecialAttack())
+		defense = float64(receiver.SpecialDefense())
+	}
+	// Weather modifiers
+	if weather == WeatherSandstorm {
+		if receiver.Type&TypeRock != 0 {
+			defense *= 1.5
+		}
+		if move.Id == MoveSolarBeam {
+			movePower /= 2
+		}
+	}
+	if weather == WeatherHail && move.Id == MoveSolarBeam {
+		movePower /= 2
+	}
+	if weather == WeatherFog {
+		if move.Id == MoveWeatherBall {
+			movePower *= 2
+		} else if move.Id == MoveSolarBeam {
+			movePower /= 2
+		}
+	}
+	damage = uint((((levelEffect * movePower * attack / defense) / 50) + 2) * modifier)
+	return damage
+}


### PR DESCRIPTION
- move sortTurns
- move damage calculation to a seperate function

Closes #254
Closes #236

Quick claw activation can be implemented in the preround using a metadata tag on the pokemon, which can be checked in `sortTurns`

Would prefer #256 to be merged in first, so I can change `*Move` to `MoveId`
