### PR TITLE
fail transaction

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -222,8 +222,9 @@ func (b *Battle) SimulateRound() ([]Transaction, bool) {
 			// Todo: account for receiver's evasion
 			receiver := b.getPokemon(t.Target.party, t.Target.partySlot)
 			if move.Accuracy() != 0 && !b.rng.Roll(int(accuracy), 100) {
-				b.QueueTransaction(EvadeTransaction{
-					User: &user,
+				b.QueueTransaction(MoveFailTransaction{
+					User:   &user,
+					Reason: FailMiss,
 				})
 				continue
 			}

--- a/battle_test.go
+++ b/battle_test.go
@@ -190,13 +190,15 @@ var _ = Describe("One round of battle", func() {
 			battle.rng = &NeverRNG
 			Expect(battle.Start()).To(Succeed())
 			t, _ := battle.SimulateRound()
-			Expect(t).To(HaveTransaction(EvadeTransaction{
-				User: charmander,
+			Expect(t).To(HaveTransaction(MoveFailTransaction{
+				User:   charmander,
+				Reason: FailMiss,
 			}))
 			battle.rng = &SimpleRNG
 			t, _ = battle.SimulateRound()
-			Expect(t).ToNot(HaveTransaction(EvadeTransaction{
-				User: charmander,
+			Expect(t).ToNot(HaveTransaction(MoveFailTransaction{
+				User:   charmander,
+				Reason: FailMiss,
 			}))
 		})
 	})

--- a/transactions.go
+++ b/transactions.go
@@ -287,11 +287,12 @@ func (t ImmobilizeTransaction) Mutate(b *Battle) {
 }
 
 // Handles evasion, misses, dodging, etc. when using moves
-type EvadeTransaction struct {
-	User *Pokemon
+type MoveFailTransaction struct {
+	User   *Pokemon
+	Reason MoveFailReason
 }
 
-func (t EvadeTransaction) Mutate(b *Battle) {
+func (t MoveFailTransaction) Mutate(b *Battle) {
 	// currently a no-op.
 }
 

--- a/types.go
+++ b/types.go
@@ -328,3 +328,11 @@ const (
 	WeatherHail
 	WeatherFog
 )
+
+type MoveFailReason uint8
+
+const (
+	FailOther MoveFailReason = iota
+	FailMiss
+	FailDodge
+)


### PR DESCRIPTION
- refactor EvadeTransaction into MoveFailTransaction
- refactor transactionDiff to take a list of types to match exactly

Also made a slight change to transactionDiff so we can make sure certain types match exactly.

closes #228
