### PR TITLE
Increase test isolation

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -513,8 +513,6 @@ var _ = Describe("Weather", func() {
 	})
 
 	Context("when weather is present, battles are affected", func() {
-		ember := GetMove(MoveEmber)
-		bubble := GetMove(MoveBubble)
 		solarBeam := GetMove(MoveSolarBeam)
 		weatherBall := GetMove(MoveWeatherBall)
 		moonlight := GetMove(MoveMoonlight)
@@ -534,42 +532,53 @@ var _ = Describe("Weather", func() {
 				Weather: WeatherClearSkies,
 			}))
 		})
-		It("should affect fire/water attacks during harsh sunlight", func() {
-			charmander := GeneratePokemon(PkmnCharmander, WithLevel(100), WithMoves(ember))
-			squirtle := GeneratePokemon(PkmnSquirtle, WithLevel(100), WithMoves(bubble))
-			p1.AddPokemon(charmander)
-			p2.AddPokemon(squirtle)
-			b.Weather = WeatherHarshSunlight
-			Expect(b.Start()).To(Succeed())
-			t, _ := b.SimulateRound()
-			// Fire boosted
-			Expect(t).To(HaveTransaction(
-				DamageTransaction{
-					User: charmander,
-					Target: target{
-						Pokemon:   *squirtle,
-						party:     1,
-						partySlot: 0,
-						Team:      1,
+
+		When("harsh sunlight", func() {
+			It("should boost fire type moves", func() {
+				// intentional non water type pokemon, intentional no supereffective type matchup
+				machamp := GeneratePokemon(PkmnMachamp, WithLevel(100), WithMoves(GetMove(MoveFlamethrower)))
+				bidoof := GeneratePokemon(PkmnBidoof, WithLevel(100), WithMoves(GetMove(MoveTackle)))
+				p1.AddPokemon(machamp)
+				p2.AddPokemon(bidoof)
+				b.Weather = WeatherHarshSunlight
+				Expect(b.Start()).To(Succeed())
+				t, _ := b.SimulateRound()
+				Expect(t).To(HaveTransaction(
+					DamageTransaction{
+						User: machamp,
+						Target: target{
+							Pokemon:   *bidoof,
+							party:     1,
+							partySlot: 0,
+							Team:      1,
+						},
+						Damage: 183,
 					},
-					Move:   ember,
-					Damage: 75,
-				},
-			))
-			// Water weakened
-			Expect(t).To(HaveTransaction(
-				DamageTransaction{
-					User: squirtle,
-					Target: target{
-						Pokemon:   *charmander,
-						party:     0,
-						partySlot: 0,
-						Team:      0,
+				))
+			})
+
+			It("should weaken water type moves", func() {
+				// intentional non water type pokemon, intentional no supereffective type matchup
+				lileep := GeneratePokemon(PkmnLileep, WithLevel(100), WithMoves(GetMove(MoveBrine)))
+				bidoof := GeneratePokemon(PkmnBidoof, WithLevel(100), WithMoves(GetMove(MoveTackle)))
+				p1.AddPokemon(lileep)
+				p2.AddPokemon(bidoof)
+				b.Weather = WeatherHarshSunlight
+				Expect(b.Start()).To(Succeed())
+				t, _ := b.SimulateRound()
+				Expect(t).To(HaveTransaction(
+					DamageTransaction{
+						User: lileep,
+						Target: target{
+							Pokemon:   *bidoof,
+							party:     1,
+							partySlot: 0,
+							Team:      1,
+						},
+						Damage: 41,
 					},
-					Move:   bubble,
-					Damage: 26,
-				},
-			))
+				))
+			})
 		})
 
 		When("raining", func() {

--- a/battle_test.go
+++ b/battle_test.go
@@ -571,42 +571,55 @@ var _ = Describe("Weather", func() {
 				},
 			))
 		})
-		It("should affect fire/water attacks during rain", func() {
-			charmander := GeneratePokemon(PkmnCharmander, WithLevel(100), WithMoves(ember))
-			squirtle := GeneratePokemon(PkmnSquirtle, WithLevel(100), WithMoves(bubble))
-			p1.AddPokemon(charmander)
-			p2.AddPokemon(squirtle)
-			b.Weather = WeatherRain
-			Expect(b.Start()).To(Succeed())
-			t, _ := b.SimulateRound()
-			// Fire weakened
-			Expect(t).To(HaveTransaction(
-				DamageTransaction{
-					User: charmander,
-					Target: target{
-						Pokemon:   *squirtle,
-						party:     1,
-						partySlot: 0,
-						Team:      1,
+
+		When("raining", func() {
+			It("should affect fire type moves", func() {
+				// intentional non water type pokemon, intentional no supereffective type matchup
+				machamp := GeneratePokemon(PkmnMachamp, WithLevel(100), WithMoves(GetMove(MoveFlamethrower)))
+				bidoof := GeneratePokemon(PkmnBidoof, WithLevel(100), WithMoves(GetMove(MoveTackle)))
+				p1.AddPokemon(machamp)
+				p2.AddPokemon(bidoof)
+				b.Weather = WeatherRain
+				Expect(b.Start()).To(Succeed())
+				t, _ := b.SimulateRound()
+				// Fire weakened
+				Expect(t).To(HaveTransaction(
+					DamageTransaction{
+						User: machamp,
+						Target: target{
+							Pokemon:   *bidoof,
+							party:     1,
+							partySlot: 0,
+							Team:      1,
+						},
+						Damage: 61,
 					},
-					Move:   ember,
-					Damage: 25,
-				},
-			))
-			// Water boosted
-			Expect(t).To(HaveTransaction(
-				DamageTransaction{
-					User: squirtle,
-					Target: target{
-						Pokemon:   *charmander,
-						party:     0,
-						partySlot: 0,
-						Team:      0,
+				))
+			})
+
+			It("should affect water type moves", func() {
+				// intentional non water type pokemon, intentional no supereffective type matchup
+				lileep := GeneratePokemon(PkmnLileep, WithLevel(100), WithMoves(GetMove(MoveBrine)))
+				bidoof := GeneratePokemon(PkmnBidoof, WithLevel(100), WithMoves(GetMove(MoveTackle)))
+				p1.AddPokemon(lileep)
+				p2.AddPokemon(bidoof)
+				b.Weather = WeatherRain
+				Expect(b.Start()).To(Succeed())
+				t, _ := b.SimulateRound()
+				// Water boosted
+				Expect(t).To(HaveTransaction(
+					DamageTransaction{
+						User: lileep,
+						Target: target{
+							Pokemon:   *bidoof,
+							party:     1,
+							partySlot: 0,
+							Team:      1,
+						},
+						Damage: 125,
 					},
-					Move:   bubble,
-					Damage: 80,
-				},
-			))
+				))
+			})
 		})
 
 		// sandstorm tests and hailing tests could be tablized

--- a/battle_test.go
+++ b/battle_test.go
@@ -186,14 +186,22 @@ var _ = Describe("One round of battle", func() {
 
 	Context("when dealing damage to a Pokemon", func() {
 		It("should account for same-type attack bonus", func() {
+			charmander = GeneratePokemon(PkmnCharmander, WithMoves(GetMove(MovePound)))
+			party1 = NewOccupiedParty(&agent1, 0, charmander)
+			bidoof := GeneratePokemon(PkmnBidoof, WithMoves(GetMove(MoveTackle)))
+			party2 = NewOccupiedParty(&agent2, 1, bidoof)
+			battle = NewBattle()
+			battle.AddParty(party1, party2)
+			battle.rng = &SimpleRNG
+
 			charmander.Moves[0] = GetMove(MoveEmber)
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(6))
-			squirtle.CurrentHP = 100
+			Expect(bidoof.CurrentHP).To(BeEquivalentTo(7))
+			bidoof.CurrentHP = 100
 			charmander.Ability = AbilityAdaptability
 			battle.SimulateRound()
-			Expect(squirtle.CurrentHP).To(BeEquivalentTo(93))
+			Expect(bidoof.CurrentHP).To(BeEquivalentTo(93))
 		})
 
 		It("should account for critical hits", func() {

--- a/battle_test.go
+++ b/battle_test.go
@@ -515,7 +515,6 @@ var _ = Describe("Weather", func() {
 	Context("when weather is present, battles are affected", func() {
 		ember := GetMove(MoveEmber)
 		bubble := GetMove(MoveBubble)
-		tackle := GetMove(MoveTackle)
 		solarBeam := GetMove(MoveSolarBeam)
 		weatherBall := GetMove(MoveWeatherBall)
 		moonlight := GetMove(MoveMoonlight)
@@ -609,39 +608,94 @@ var _ = Describe("Weather", func() {
 				},
 			))
 		})
-		It("should damage/cause side effects during sandstorm", func() {
-			geodude := GeneratePokemon(PkmnGeodude, WithLevel(50), WithMoves(tackle))
-			bulbasaur := GeneratePokemon(PkmnBulbasaur, WithLevel(50), WithMoves(solarBeam))
-			p1.AddPokemon(geodude)
-			p2.AddPokemon(bulbasaur)
-			b.Weather = WeatherSandstorm
-			b.metadata[MetaWeatherTurns] = 5
-			Expect(b.Start()).To(Succeed())
-			t, _ := b.SimulateRound()
-			// Weaken solar beam, SPDEF of rock type
-			Expect(t).To(HaveTransaction(DamageTransaction{
-				User: bulbasaur,
-				Target: target{
-					Pokemon:   *geodude,
-					party:     0,
-					partySlot: 0,
-					Team:      0,
-				},
-				Move:   solarBeam,
-				Damage: 55,
-			}))
-			// Damage from sandstorm
-			Expect(t).To(HaveTransaction(DamageTransaction{
-				User: nil,
-				Target: target{
-					Pokemon:   *bulbasaur,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-				Move:   nil,
-				Damage: 6,
-			}))
+
+		// sandstorm tests and hailing tests could be tablized
+		When("sandstorm", func() {
+			It("should weaken solar beam", func() {
+				bidoof := GeneratePokemon(PkmnBidoof,
+					WithLevel(5),
+					WithIVs([6]uint8{31, 0, 31, 0, 31, 0}),
+					WithEVs([6]uint8{200, 0, 31, 0, 31, 0}),
+					WithMoves(GetMove(MoveTackle)),
+				)
+				bulbasaur := GeneratePokemon(PkmnBulbasaur,
+					WithLevel(5),
+					WithIVs([6]uint8{31, 0, 31, 0, 31, 0}),
+					WithEVs([6]uint8{200, 0, 31, 0, 31, 0}),
+					WithMoves(GetMove(MoveSolarBeam)),
+				)
+				p1.AddPokemon(bidoof)
+				p2.AddPokemon(bulbasaur)
+				Expect(b.Start()).To(Succeed())
+
+				// TODO: compare doing solar beam WITH sandstorm deals less damage than WITHOUT sandstorm.
+				t, _ := b.SimulateRound()
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: bulbasaur,
+					Target: target{
+						Pokemon:   *bidoof,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					Move:   solarBeam,
+					Damage: 18,
+				}))
+
+				Expect(t).ToNot(HaveTransaction(FaintTransaction{}))
+
+				b.QueueTransaction(
+					WeatherTransaction{
+						Weather: WeatherSandstorm,
+						Turns:   5,
+					},
+					HealTransaction{
+						Target: b.getPokemon(0, 0),
+						Amount: 100,
+					},
+					HealTransaction{
+						Target: b.getPokemon(1, 0),
+						Amount: 100,
+					},
+				)
+				b.ProcessQueue()
+
+				t, _ = b.SimulateRound()
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: bulbasaur,
+					Target: target{
+						Pokemon:   *bidoof,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					Move:   solarBeam,
+					Damage: 10,
+				}))
+			})
+
+			It("should cause sandstorm damage", func() {
+				bidoof := GeneratePokemon(PkmnBidoof, WithMoves(GetMove(MoveTackle)))
+				bulbasaur := GeneratePokemon(PkmnBulbasaur, WithMoves(GetMove(MoveSolarBeam)))
+				p1.AddPokemon(bidoof)
+				p2.AddPokemon(bulbasaur)
+				b.Weather = WeatherHail
+				b.metadata[MetaWeatherTurns] = 5
+				Expect(b.Start()).To(Succeed())
+				t, _ := b.SimulateRound()
+
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: nil,
+					Target: target{
+						Pokemon:   *bulbasaur,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Move:   nil,
+					Damage: 0,
+				}))
+			})
 		})
 
 		When("hailing", func() {

--- a/util_test.go
+++ b/util_test.go
@@ -57,6 +57,22 @@ func transactionDiff(expected, got Transaction) map[string]diff {
 		rfA := rA.Field(i)
 		rfB := rB.FieldByName(typeField.Name)
 
+		if !rfB.IsValid() {
+			result[typeField.Name] = diff{
+				expected: rfA.Interface(),
+				got:      "invalid reflection value",
+			}
+			continue
+		}
+
+		if rfA.Type() != rfB.Type() {
+			result[typeField.Name] = diff{
+				expected: rfA.Type(),
+				got:      rfB.Type(),
+			}
+			continue
+		}
+
 		if rfA.Type() == reflect.TypeOf(&Pokemon{}) {
 			a := rfA.Interface().(*Pokemon)
 			b := rfB.Interface().(*Pokemon)


### PR DESCRIPTION
- improve weather hailing tests
- improve sandstorm tests to not include a supereffective type matchup
- improve raining tests to not include type matchups or same type attack boost
- improve harsh sunlight tests
- improve same type attack bonus test to not include a supereffective type matchup

There were a lot of tests that were preventing me from implementing #85 effectively, because they inadvertently had supereffective/not effective type matchups.

This is definitely something we should be on the lookout for in the future.
