### PR TITLE
Add type matchups to damage calculation

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -266,7 +266,7 @@ var _ = Describe("One round of battle", func() {
 					Team:      1,
 				},
 				Move:   GetMove(MoveFireFang),
-				Damage: 9,
+				Damage: 8,
 			}))
 		})
 

--- a/battle_test.go
+++ b/battle_test.go
@@ -206,68 +206,123 @@ var _ = Describe("One round of battle", func() {
 			Expect(bidoof.CurrentHP).To(BeEquivalentTo(93))
 		})
 
-		It("should account for supereffective type matchups", func() {
-			a1 := newRcAgent()
-			a2 := newRcAgent()
-			_a1 := Agent(a1)
-			_a2 := Agent(a2)
-			pkmn1 := GeneratePokemon(
-				PkmnMightyena,
-				WithIVs([6]uint8{31, 0, 31, 0, 31, 31}),
-				WithMoves(
-					GetMove(MoveFireFang),
-					GetMove(MoveTackle),
-				),
+		Context("Type Matchups", func() {
+			var (
+				a1  rcAgent
+				a2  rcAgent
+				_a1 Agent
+				_a2 Agent
+				b   *Battle
 			)
-			party1 = NewOccupiedParty(&_a1, 0, pkmn1)
-			pkmn2 := GeneratePokemon(
-				PkmnTurtwig,
-				WithMoves(GetMove(MoveTackle)),
-				WithIVs([6]uint8{31, 31, 31, 31, 31, 0}),
-			)
-			party2 = NewOccupiedParty(&_a2, 1, pkmn2)
-			b := NewBattle()
-			b.AddParty(party1, party2)
-			b.rng = &SimpleRNG
-			Expect(b.Start()).To(Succeed())
 
-			// TODO: test the difference in damage between the transactions rather than the exact values of the transactions
-			// TODO: make it so that target doesn't need to include `Pokemon` or `Team`
-			a1 <- FightTurn{Move: 1, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
-			a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
-			t, _ := b.SimulateRound()
-			Expect(t).To(HaveTransaction(DamageTransaction{
-				User: pkmn1,
-				Target: target{
-					Pokemon:   *pkmn2,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-				Move:   GetMove(MoveTackle),
-				Damage: 3,
-			}))
-
-			b.QueueTransaction(HealTransaction{
-				Target: pkmn2,
-				Amount: 200,
+			BeforeEach(func() {
+				a1 = newRcAgent()
+				a2 = newRcAgent()
+				_a1 = Agent(a1)
+				_a2 = Agent(a2)
+				b = NewBattle()
+				b.rng = SimpleRNG()
 			})
-			b.ProcessQueue()
 
-			a1 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
-			a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
-			t, _ = b.SimulateRound()
-			Expect(t).To(HaveTransaction(DamageTransaction{
-				User: pkmn1,
-				Target: target{
-					Pokemon:   *pkmn2,
-					party:     1,
-					partySlot: 0,
-					Team:      1,
-				},
-				Move:   GetMove(MoveFireFang),
-				Damage: 8,
-			}))
+			It("should account for supereffective type matchups", func() {
+				pkmn1 := GeneratePokemon(
+					PkmnMightyena,
+					WithIVs([6]uint8{31, 0, 31, 0, 31, 31}),
+					WithMoves(
+						GetMove(MoveFireFang),
+						GetMove(MoveTackle),
+					),
+				)
+				party1 = NewOccupiedParty(&_a1, 0, pkmn1)
+				pkmn2 := GeneratePokemon(
+					PkmnTurtwig,
+					WithMoves(GetMove(MoveTackle)),
+					WithIVs([6]uint8{31, 31, 31, 31, 31, 0}),
+				)
+				party2 = NewOccupiedParty(&_a2, 1, pkmn2)
+				b.AddParty(party1, party2)
+				Expect(b.Start()).To(Succeed())
+
+				// TODO: test the difference in damage between the transactions rather than the exact values of the transactions
+				// TODO: make it so that target doesn't need to include `Pokemon` or `Team`
+				a1 <- FightTurn{Move: 1, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
+				a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
+				t, _ := b.SimulateRound()
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: pkmn1,
+					Target: target{
+						Pokemon:   *pkmn2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Move:   GetMove(MoveTackle),
+					Damage: 3,
+				}))
+
+				b.QueueTransaction(HealTransaction{
+					Target: pkmn2,
+					Amount: 200,
+				})
+				b.ProcessQueue()
+
+				a1 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
+				a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
+				t, _ = b.SimulateRound()
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: pkmn1,
+					Target: target{
+						Pokemon:   *pkmn2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Move:   GetMove(MoveFireFang),
+					Damage: 8,
+				}))
+			})
+
+			It("should have no effect", func() {
+				pkmn1 := GeneratePokemon(
+					PkmnGastly,
+					WithMoves(GetMove(MoveShadowBall)),
+				)
+				party1 = NewOccupiedParty(&_a1, 0, pkmn1)
+				pkmn2 := GeneratePokemon(
+					PkmnBidoof,
+					WithMoves(GetMove(MoveTackle)),
+				)
+				party2 = NewOccupiedParty(&_a2, 1, pkmn2)
+				b.AddParty(party1, party2)
+				Expect(b.Start()).To(Succeed())
+
+				// TODO: make it so that target doesn't need to include `Pokemon` or `Team`
+				a1 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
+				a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
+				t, _ := b.SimulateRound()
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: pkmn1,
+					Target: target{
+						Pokemon:   *pkmn2,
+						party:     1,
+						partySlot: 0,
+						Team:      1,
+					},
+					Move:   GetMove(MoveShadowBall),
+					Damage: 0,
+				}))
+				Expect(t).To(HaveTransaction(DamageTransaction{
+					User: pkmn2,
+					Target: target{
+						Pokemon:   *pkmn1,
+						party:     0,
+						partySlot: 0,
+						Team:      0,
+					},
+					Move:   GetMove(MoveTackle),
+					Damage: 0,
+				}))
+			})
 		})
 
 		It("should account for critical hits", func() {

--- a/battle_test.go
+++ b/battle_test.go
@@ -206,6 +206,70 @@ var _ = Describe("One round of battle", func() {
 			Expect(bidoof.CurrentHP).To(BeEquivalentTo(93))
 		})
 
+		It("should account for supereffective type matchups", func() {
+			a1 := newRcAgent()
+			a2 := newRcAgent()
+			_a1 := Agent(a1)
+			_a2 := Agent(a2)
+			pkmn1 := GeneratePokemon(
+				PkmnMightyena,
+				WithIVs([6]uint8{31, 0, 31, 0, 31, 31}),
+				WithMoves(
+					GetMove(MoveFireFang),
+					GetMove(MoveTackle),
+				),
+			)
+			party1 = NewOccupiedParty(&_a1, 0, pkmn1)
+			pkmn2 := GeneratePokemon(
+				PkmnTurtwig,
+				WithMoves(GetMove(MoveTackle)),
+				WithIVs([6]uint8{31, 31, 31, 31, 31, 0}),
+			)
+			party2 = NewOccupiedParty(&_a2, 1, pkmn2)
+			b := NewBattle()
+			b.AddParty(party1, party2)
+			b.rng = &SimpleRNG
+			Expect(b.Start()).To(Succeed())
+
+			// TODO: test the difference in damage between the transactions rather than the exact values of the transactions
+			// TODO: make it so that target doesn't need to include `Pokemon` or `Team`
+			a1 <- FightTurn{Move: 1, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
+			a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
+			t, _ := b.SimulateRound()
+			Expect(t).To(HaveTransaction(DamageTransaction{
+				User: pkmn1,
+				Target: target{
+					Pokemon:   *pkmn2,
+					party:     1,
+					partySlot: 0,
+					Team:      1,
+				},
+				Move:   GetMove(MoveTackle),
+				Damage: 3,
+			}))
+
+			b.QueueTransaction(HealTransaction{
+				Target: pkmn2,
+				Amount: 200,
+			})
+			b.ProcessQueue()
+
+			a1 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn2, party: 1, partySlot: 0, Team: 1}}
+			a2 <- FightTurn{Move: 0, Target: target{Pokemon: *pkmn1, party: 0, partySlot: 0, Team: 0}}
+			t, _ = b.SimulateRound()
+			Expect(t).To(HaveTransaction(DamageTransaction{
+				User: pkmn1,
+				Target: target{
+					Pokemon:   *pkmn2,
+					party:     1,
+					partySlot: 0,
+					Team:      1,
+				},
+				Move:   GetMove(MoveFireFang),
+				Damage: 9,
+			}))
+		})
+
 		It("should account for critical hits", func() {
 			battle.rng = AlwaysRNG()
 			Expect(battle.Start()).To(Succeed())

--- a/calc.go
+++ b/calc.go
@@ -16,7 +16,9 @@ func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damag
 		}
 	}
 
-	modifier := weatherMod * stab
+	elemental := GetElementalEffect(move.Type(), receiver.EffectiveType())
+
+	modifier := weatherMod * float64(elemental) * stab
 	levelEffect := float64((2 * user.Level / 5) + 2)
 	movePower := float64(move.Power())
 	attack := float64(user.Attack())

--- a/calc.go
+++ b/calc.go
@@ -16,9 +16,7 @@ func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damag
 		}
 	}
 
-	elemental := GetElementalEffect(move.Type(), receiver.EffectiveType())
-
-	modifier := weatherMod * float64(elemental) * stab
+	modifier := weatherMod * stab
 	levelEffect := float64((2 * user.Level / 5) + 2)
 	movePower := float64(move.Power())
 	attack := float64(user.Attack())
@@ -48,5 +46,11 @@ func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damag
 		}
 	}
 	damage = uint((((levelEffect * movePower * attack / defense) / 50) + 2) * modifier)
+	elementalEffect := GetElementalEffect(move.Type(), receiver.EffectiveType())
+	if elementalEffect > NormalEffect {
+		damage <<= elementalEffect
+	} else if elementalEffect < NormalEffect {
+		damage >>= elementalEffect * -1 // bitshift operand must be positive
+	}
 	return damage
 }

--- a/types.go
+++ b/types.go
@@ -94,7 +94,7 @@ var typeStrings = map[Type]string{
 // Represents effectiveness of an elemental type matchup.
 type Effectiveness int8
 
-const NoEffect Effectiveness = math.MinInt8 // separate because it fucks up the iota
+const NoEffect Effectiveness = math.MinInt8 + 1 // separate because it fucks up the iota
 const (
 	VeryIneffective Effectiveness = iota - 2
 	Ineffective

--- a/types.go
+++ b/types.go
@@ -92,15 +92,15 @@ var typeStrings = map[Type]string{
 }
 
 // Represents effectiveness of an elemental type matchup.
-type Effectiveness float64
+type Effectiveness int8
 
+const NoEffect Effectiveness = math.MinInt8 // separate because it fucks up the iota
 const (
-	NoEffect           Effectiveness = 0
-	VeryIneffective    Effectiveness = 0.25
-	Ineffective        Effectiveness = 0.5
-	NormalEffect       Effectiveness = 1
-	SuperEffective     Effectiveness = 2
-	VerySuperEffective Effectiveness = 4
+	VeryIneffective Effectiveness = iota - 2
+	Ineffective
+	NormalEffect
+	SuperEffective
+	VerySuperEffective
 )
 
 var noEffect = map[Type]Type{
@@ -160,14 +160,8 @@ func GetElementalEffect(move, def Type) Effectiveness {
 
 	reduce := bits.OnesCount32(uint32(halfEffect[move] & def))
 	increase := bits.OnesCount32(uint32(doubleEffect[move] & def))
-	effect := (increase - reduce) * 2
-	if effect == 0 {
-		return NormalEffect
-	} else if effect > 0 {
-		return Effectiveness(effect)
-	} else {
-		return Effectiveness(1 / math.Abs(float64(effect)))
-	}
+	effect := increase - reduce
+	return Effectiveness(effect)
 }
 
 func (t Type) String() string {


### PR DESCRIPTION
This PR also refactors how the `Effectiveness` type works such that no casts to `float64` are necessary.

closes #85 