### PR TITLE
Better Test Utilities

### DIFF
--- a/battle_test.go
+++ b/battle_test.go
@@ -153,7 +153,6 @@ var _ = Describe("One round of battle", func() {
 			Expect(battle.Start()).To(Succeed())
 			t, _ := battle.SimulateRound()
 			Expect(t).To(HaveLen(2))
-			pound := GetMove(MovePound)
 			Expect(t).To(HaveTransaction(DamageTransaction{
 				User: charmander,
 				Target: target{
@@ -162,7 +161,7 @@ var _ = Describe("One round of battle", func() {
 					partySlot: 0,
 					Team:      1,
 				},
-				Move:   pound,
+				Move:   GetMove(MovePound),
 				Damage: 3,
 			}))
 			Expect(t).To(HaveTransaction(DamageTransaction{
@@ -173,7 +172,7 @@ var _ = Describe("One round of battle", func() {
 					partySlot: 0,
 					Team:      0,
 				},
-				Move:   pound,
+				Move:   GetMove(MovePound),
 				Damage: 3,
 			}))
 		})
@@ -552,7 +551,7 @@ var _ = Describe("Turn priority", func() {
 						Team:      0,
 					},
 					Damage: 5,
-					Move:   GetMove(MoveSolarBeam),
+					Move:   GetMove(MoveFakeOut),
 				},
 				DamageTransaction{
 					User: p1,
@@ -569,9 +568,8 @@ var _ = Describe("Turn priority", func() {
 		})
 
 		It("should handle faster Pokemon first", func() {
-			pound := GetMove(MovePound)
-			charmander := GeneratePokemon(PkmnCharmander, WithMoves(pound))
-			ninjask := GeneratePokemon(PkmnNinjask, WithMoves(pound))
+			charmander := GeneratePokemon(PkmnCharmander, defaultMoveOpt)
+			ninjask := GeneratePokemon(PkmnNinjask, defaultMoveOpt)
 			p1 := NewOccupiedParty(&a1, 0, charmander)
 			p2 := NewOccupiedParty(&a2, 1, ninjask) // ninjask is faster than charmander
 			b := NewBattle()
@@ -588,7 +586,7 @@ var _ = Describe("Turn priority", func() {
 						partySlot: 0,
 						Team:      0,
 					},
-					Move:   pound,
+					Move:   GetMove(MovePound),
 					Damage: 3,
 				},
 				DamageTransaction{
@@ -599,7 +597,7 @@ var _ = Describe("Turn priority", func() {
 						partySlot: 0,
 						Team:      1,
 					},
-					Move:   pound,
+					Move:   GetMove(MovePound),
 					Damage: 3,
 				},
 			))

--- a/battle_test.go
+++ b/battle_test.go
@@ -982,9 +982,9 @@ var _ = Describe("Weather", func() {
 				Move:   weatherBall,
 				Damage: 22,
 			}))
-			Expect(t).To(HaveTransaction(HealTransaction{
-				Target: bulbasaur,
-				Amount: 7,
+			Expect(t).To(HaveTransaction(InflictStatusTransaction{
+				Target:       bulbasaur,
+				StatusEffect: StatusPoison,
 			}))
 		})
 	})

--- a/battle_test.go
+++ b/battle_test.go
@@ -982,9 +982,9 @@ var _ = Describe("Weather", func() {
 				Move:   weatherBall,
 				Damage: 22,
 			}))
-			Expect(t).To(HaveTransaction(InflictStatusTransaction{
-				Target:       bulbasaur,
-				StatusEffect: StatusPoison,
+			Expect(t).To(HaveTransaction(HealTransaction{
+				Target: bulbasaur,
+				Amount: 7,
 			}))
 		})
 	})

--- a/battle_test.go
+++ b/battle_test.go
@@ -552,7 +552,7 @@ var _ = Describe("Turn priority", func() {
 						Team:      0,
 					},
 					Damage: 5,
-					Move:   GetMove(MoveFakeOut),
+					Move:   GetMove(MoveSolarBeam),
 				},
 				DamageTransaction{
 					User: p1,

--- a/util_test.go
+++ b/util_test.go
@@ -100,6 +100,13 @@ func transactionDiff(expected, got Transaction) map[string]diff {
 					got:      rfB.Interface(),
 				}
 			}
+		} else if rfA.Type() == reflect.TypeOf(&Move{}) {
+			if !rfB.IsNil() && !reflect.DeepEqual(rfA.Interface(), rfB.Interface()) {
+				result[typeField.Name] = diff{
+					expected: rfA.Interface(),
+					got:      rfB.Interface(),
+				}
+			}
 		} else {
 			// Special case to allow fields with primitive types or nil pointers to be ignored when comparing.
 			// If either A or B is a type's zero value, or nil, it won't bother comparing them.

--- a/util_test.go
+++ b/util_test.go
@@ -101,10 +101,14 @@ func transactionDiff(expected, got Transaction) map[string]diff {
 				}
 			}
 		} else if rfA.Type() == reflect.TypeOf(&Move{}) {
-			if !rfB.IsNil() && !reflect.DeepEqual(rfA.Interface(), rfB.Interface()) {
-				result[typeField.Name] = diff{
-					expected: rfA.Interface(),
-					got:      rfB.Interface(),
+			if !rfB.IsNil() {
+				mvA := rfA.Interface().(*Move)
+				mvB := rfB.Interface().(*Move)
+				if mvA.Id != mvB.Id {
+					result[typeField.Name] = diff{
+						expected: mvA.String(),
+						got:      mvB.String(),
+					}
 				}
 			}
 		} else {

--- a/util_test.go
+++ b/util_test.go
@@ -229,17 +229,16 @@ func (matcher *singleTransactionMatcher) FailureMessage(actual interface{}) (mes
 	case []Transaction:
 		first, count := findCountTransactionIdxWithMatchingType(transactions, matcher.expected)
 		if first == -1 {
-			return fmt.Sprintf("Expected the sequence of transactions to include: %T, but none of the same type were found in %d transactions.",
+			gotText := ""
+			for _, t := range transactions {
+				gotText += fmt.Sprintf("- %T\n", t)
+			}
+			return fmt.Sprintf("Expected the sequence of transactions to include %T, but received:\n%s",
 				matcher.expected,
-				len(transactions),
+				gotText,
 			)
 		} else if count == 1 {
-			return fmt.Sprintf("Expected:\n\t%T: %+v\n\nInstead, got:\n\t%T: %+v",
-				matcher.expected,
-				matcher.expected,
-				transactions[first],
-				transactions[first],
-			)
+			return getDiffText(transactions, matcher.expected)
 		} else {
 			diffText := getDiffText(transactions, matcher.expected)
 			return fmt.Sprintf("The closest of %d total %s", count, diffText)
@@ -275,7 +274,6 @@ func checkTransactionOrder(check, want []Transaction) (success bool, diffText st
 			break
 		}
 		if reflect.TypeOf(t) != reflect.TypeOf(want[i]) {
-			i += 1
 			continue
 		}
 		d := transactionDiff(want[i], t)


### PR DESCRIPTION
This PR adds more descriptive messages to failing tests.

## Example 1
A missing/incorrect field in ordered transactions is difficult to deduce from the error message.

For the following code:
```golang
Expect(t).To(HaveTransactionsInOrder(
	HealTransaction{
		Target: charmander,
		Amount: 0,
	},
	DamageTransaction{
		User: bulbasaur,
		Target: target{
			Pokemon:   *charmander,
			party:     1,
			partySlot: 0,
			Team:      1,
		},
		Move:   GetMove(MoveTackle), // Should be MovePound
		Damage: 3,
	},
))
```

The current error is as follows:
```
Expected the sequence of transactions to have these transactions in this order:
    0: pokemonbattlelib.HealTransaction: {Target:Charmander Amount:0}
    1: pokemonbattlelib.DamageTransaction: {User:Bulbasaur Target:Party 1 (Slot 0) | Team 1 | Pokemon:
    Charmander Move:Fire Blast Damage:3 StatusEffect:}
```

This is my attempt at a solution:
```
Expected the sequence of transactions to have these transactions in this order:
    1. pokemonbattlelib.DamageTransaction
    2. pokemonbattlelib.DamageTransaction

    Received the following transactions:
    1. pokemonbattlelib.DamageTransaction
    2. pokemonbattlelib.DamageTransaction

    The closest transaction that failed to match is shown below:
    pokemonbattlelib.DamageTransaction has 1/5 fields that do not match:
    - Move
    Expected: Tackle
    Received: Pound
```
## Example 2
When matching single transactions, it is sometimes tricky to see which fields are affected when two transactions are not equivalent.
The following error is not the best example, but I've had cases where it's really difficult to find the field that is wrong, especially when working with arrays.
```Expected:
        pokemonbattlelib.DamageTransaction: {User:Bulbasaur Target:Party 0 (Slot 0) | Team 1 | Pokemon:
    Charmander Move:Pound Damage:3 StatusEffect:}

    Instead, got:
        pokemonbattlelib.DamageTransaction: {User:Bulbasaur Target:Party 1 (Slot 0) | Team 1 | Pokemon:
    Charmander Move:Pound Damage:3 StatusEffect:}
```

Becomes this:
```
pokemonbattlelib.DamageTransaction has 1/5 fields that do not match:
    - Target
    Expected: Party 0 (Slot 0) | Team 1 | Pokemon:
    Charmander
    Received: Party 1 (Slot 0) | Team 1 | Pokemon:
    Charmander
```

## Example 3
We should be able to see which transactions occurred instead of knowing that one is missing.

Currently, we get the following message:
```
Expected the sequence of transactions to include: pokemonbattlelib.InflictStatusTransaction, but none of the same type were found in 2 transactions.
```

Now, we get this message:
```
Expected the sequence of transactions to include pokemonbattlelib.InflictStatusTransaction, but received:
    - pokemonbattlelib.DamageTransaction
    - pokemonbattlelib.HealTransaction
```

Additionally, made `Move` check a strict match similar to how Pokemon are compared in the matchers.
Closes #289 