### PR TITLE
Refactor target to have ground truth pointer

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -27,6 +27,10 @@ var _ = Describe("Agents", func() {
 			real := b.getPokemon(ctx.Opponents[0])
 			Expect(ctx.Opponents[0].Pokemon).ToNot(BeIdenticalTo(real))
 			// Expect(ctx.Opponents[0].Pokemon.Moves[0]).ToNot(BeIdenticalTo(real.Moves[0])) // See #294
+			for t := range ctx.Targets {
+				real := b.getPokemon(ctx.Targets[t]) // because range makes a copy of the array
+				Expect(ctx.Targets[t].Pokemon).ToNot(BeIdenticalTo(real))
+			}
 			return FightTurn{Move: 0, Target: ctx.Opponents[0]}
 		}))
 		party1 := NewOccupiedParty(&_a1, 0, GeneratePokemon(PkmnCharmander, defaultMoveOpt))

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,45 @@
+package pokemonbattlelib
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type cheater struct{}
+
+func (a cheater) Act(ctx *BattleContext) Turn {
+	ctx.Pokemon.Type |= TypeDragon
+	return FightTurn{Move: 0, Target: ctx.Opponents[0]}
+}
+
+type funkyAgent func(*BattleContext) Turn
+
+func (a funkyAgent) Act(ctx *BattleContext) Turn {
+	return a(ctx)
+}
+
+var _ = Describe("Agents", func() {
+	It("should never receive a ground truth reference to pokemon in the battle", func() {
+		b := NewBattle()
+		a1 := newRcAgent()
+		_a1 := Agent(a1)
+		a2 := Agent(funkyAgent(func(ctx *BattleContext) Turn {
+			real := b.getPokemon(ctx.Opponents[0])
+			Expect(ctx.Opponents[0].Pokemon).ToNot(BeIdenticalTo(real))
+			// Expect(ctx.Opponents[0].Pokemon.Moves[0]).ToNot(BeIdenticalTo(real.Moves[0])) // See #294
+			return FightTurn{Move: 0, Target: ctx.Opponents[0]}
+		}))
+		party1 := NewOccupiedParty(&_a1, 0, GeneratePokemon(PkmnCharmander, defaultMoveOpt))
+		party2 := NewOccupiedParty(&a2, 1, GeneratePokemon(PkmnSquirtle, defaultMoveOpt))
+		b.AddParty(party1, party2)
+		Expect(b.Start()).To(Succeed())
+		a1 <- FightTurn{
+			Move: 0,
+			Target: target{
+				party:     1,
+				partySlot: 0,
+			},
+		}
+		b.SimulateRound()
+	})
+})

--- a/agent_test.go
+++ b/agent_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Agents", func() {
 		a2 := Agent(funkyAgent(func(ctx *BattleContext) Turn {
 			real := b.getPokemon(ctx.Opponents[0])
 			Expect(ctx.Opponents[0].Pokemon).ToNot(BeIdenticalTo(real))
-			// Expect(ctx.Opponents[0].Pokemon.Moves[0]).ToNot(BeIdenticalTo(real.Moves[0])) // See #294
+			Expect(ctx.Opponents[0].Pokemon.Moves[0]).ToNot(BeIdenticalTo(real.Moves[0])) // See #294
 			for t := range ctx.Targets {
 				real := b.getPokemon(ctx.Targets[t]) // because range makes a copy of the array
 				Expect(ctx.Targets[t].Pokemon).ToNot(BeIdenticalTo(real))

--- a/battle.go
+++ b/battle.go
@@ -138,20 +138,20 @@ func (b *Battle) sortTurns(turns *[]TurnContext) {
 	sort.SliceStable(*turns, func(i, j int) bool {
 		turnA := (*turns)[i].Turn
 		turnB := (*turns)[j].Turn
-		ctxA := (*turns)[i].Context
-		ctxB := (*turns)[j].Context
+		pkmnA := (*turns)[i].User.Pokemon
+		pkmnB := (*turns)[j].User.Pokemon
 		if reflect.TypeOf(turnA) == reflect.TypeOf(turnB) {
 			switch turnA.(type) {
 			case FightTurn:
 				ftA := turnA.(FightTurn)
 				ftB := turnB.(FightTurn)
-				mvA := ctxA.Pokemon.Moves[ftA.Move]
-				mvB := ctxB.Pokemon.Moves[ftB.Move]
+				mvA := pkmnA.Moves[ftA.Move]
+				mvB := pkmnB.Moves[ftB.Move]
 				if mvA.Priority() != mvB.Priority() {
 					return mvA.Priority() > mvB.Priority()
 				}
 				// speedy pokemon should go first
-				return ctxA.Pokemon.Speed() > ctxB.Pokemon.Speed()
+				return pkmnA.Speed() > pkmnB.Speed()
 			}
 		} else {
 			// make higher priority turns go first
@@ -192,8 +192,7 @@ func (b *Battle) SimulateRound() ([]Transaction, bool) {
 					partySlot: j,
 					Team:      party.team,
 				},
-				Turn:    turn,
-				Context: ctx,
+				Turn: turn,
 			})
 		}
 	}
@@ -648,9 +647,8 @@ type Turn interface {
 
 // Wrapper used to determine turn order in a battle
 type TurnContext struct {
-	User    target         // The pokemon that made this turn.
-	Turn    Turn           // A copy of the turn that a Pokemon made using an Agent
-	Context *BattleContext // The context in which the Pokemon took its turn
+	User target // The pokemon that made this turn.
+	Turn Turn   // A copy of the turn that a Pokemon made using an Agent
 }
 
 // A turn to represent a Pokemon using a Move.

--- a/battle.go
+++ b/battle.go
@@ -436,8 +436,8 @@ func (b *Battle) SimulateRound() ([]Transaction, bool) {
 func (b *Battle) postRound() {
 	blog.Println("Post-round")
 	// Effects on every Pokemon
-	for _, t := range b.GetTargets() {
-		pkmn := b.getPokemon(t)
+	for _, t := range b.GetTargetsRef() {
+		pkmn := t.Pokemon
 		// Status effects
 		if pkmn.StatusEffects.check(StatusBurn) || pkmn.StatusEffects.check(StatusPoison) || pkmn.StatusEffects.check(StatusBadlyPoison) {
 			cond := pkmn.StatusEffects & StatusNonvolatileMask
@@ -450,7 +450,7 @@ func (b *Battle) postRound() {
 				damage = pkmn.MaxHP() / 16
 			}
 			b.QueueTransaction(DamageTransaction{
-				Target:       t,
+				Target:       *t,
 				Damage:       damage,
 				StatusEffect: cond,
 			})
@@ -461,7 +461,7 @@ func (b *Battle) postRound() {
 			if pkmn.EffectiveType()&(TypeRock|TypeGround|TypeSteel) == 0 {
 				damage := pkmn.MaxHP() / 16
 				b.QueueTransaction(DamageTransaction{
-					Target: t,
+					Target: *t,
 					Damage: damage,
 				})
 			}
@@ -469,14 +469,14 @@ func (b *Battle) postRound() {
 			if pkmn.EffectiveType()&TypeIce == 0 {
 				damage := pkmn.MaxHP() / 16
 				b.QueueTransaction(DamageTransaction{
-					Target: t,
+					Target: *t,
 					Damage: damage,
 				})
 			}
 		}
 		if pkmn.HeldItem.Category() == ItemCategoryInAPinch && pkmn.CurrentHP <= pkmn.Stats[StatHP]/4 {
 			b.QueueTransaction(ItemTransaction{
-				Target: t,
+				Target: *t,
 				IsHeld: true,
 				Item:   pkmn.HeldItem,
 			})
@@ -484,7 +484,7 @@ func (b *Battle) postRound() {
 		// Held item effects
 		if pkmn.HeldItem != ItemNone {
 			b.QueueTransaction(ItemTransaction{
-				Target: t,
+				Target: *t,
 				IsHeld: true,
 				Item:   pkmn.HeldItem,
 			})

--- a/transactions.go
+++ b/transactions.go
@@ -279,7 +279,7 @@ func (t FaintTransaction) Mutate(b *Battle) {
 			// auto send out next pokemon
 			b.QueueTransaction(SendOutTransaction{
 				Target: target{
-					Pokemon:   *b.getPokemonInBattle(t.Target.party, i),
+					Pokemon:   b.getPokemonInBattle(t.Target.party, i),
 					party:     t.Target.party,
 					partySlot: i,
 					Team:      t.Target.Team,

--- a/transactions.go
+++ b/transactions.go
@@ -22,7 +22,7 @@ func (t DamageTransaction) Mutate(b *Battle) {
 	if t.Damage == 0 {
 		t.Damage = 1
 	}
-	receiver := b.getPokemon(t.Target)
+	receiver := t.Target.Pokemon
 	if t.Move != nil {
 		t.User.metadata[MetaLastMove] = t.Move
 	}
@@ -106,7 +106,7 @@ type ItemTransaction struct {
 }
 
 func (t ItemTransaction) Mutate(b *Battle) {
-	target := b.getPokemon(t.Target)
+	target := t.Target.Pokemon
 	if t.Item.Flags()&FlagConsumable > 0 {
 		if t.IsHeld {
 			t.Item = target.HeldItem // auto-correct if the value is not present or does not match
@@ -256,10 +256,9 @@ type CureStatusTransaction struct {
 }
 
 func (t CureStatusTransaction) Mutate(b *Battle) {
-	receiver := b.getPokemon(t.Target)
-	receiver.StatusEffects.clear(t.StatusEffect)
+	t.Target.Pokemon.StatusEffects.clear(t.StatusEffect)
 	if t.StatusEffect.check(StatusSleep) {
-		delete(receiver.metadata, MetaSleepTime)
+		delete(t.Target.Pokemon.metadata, MetaSleepTime)
 	}
 }
 
@@ -339,7 +338,7 @@ type ImmobilizeTransaction struct {
 }
 
 func (t ImmobilizeTransaction) Mutate(b *Battle) {
-	receiver := b.getPokemon(t.Target)
+	receiver := t.Target.Pokemon
 	if t.StatusEffect.check(StatusSleep) {
 		receiver.metadata[MetaSleepTime] = receiver.metadata[MetaSleepTime].(int) - 1
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -26,7 +26,7 @@ func comparePokemon(a, b *Pokemon) bool {
 
 // Used for custom gomega matchers. For simplicity, the fields of the struct are hardcoded. If we need to add more fields to `target` something is probably wrong.
 func compareTargets(a, b target) bool {
-	return comparePokemon(&a.Pokemon, &b.Pokemon) &&
+	return comparePokemon(a.Pokemon, b.Pokemon) &&
 		a.party == b.party &&
 		a.partySlot == b.partySlot &&
 		a.Team == b.Team


### PR DESCRIPTION
- add agent test
- refactor target to contain a pointer to the ground truth pokemon instead of a copy

This PR is an effort to consolidate how pokemon are accessed into one easy mechanism. An added bonus is a potentially reduced lifetime for values copied when creating battle contexts for Agents, which would mean less memory usage over general usage.

Now the code more clearly defines where pokemon are copied, and where pokemon are passed by reference.

Another bonus, it closes #294
