### PR TITLE
add Party type, and refactor most tests for consistency

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -33,9 +33,10 @@ var _ = Describe("Agents", func() {
 			}
 			return FightTurn{Move: 0, Target: ctx.Opponents[0]}
 		}))
-		party1 := NewOccupiedParty(&_a1, 0, GeneratePokemon(PkmnCharmander, defaultMoveOpt))
-		party2 := NewOccupiedParty(&a2, 1, GeneratePokemon(PkmnSquirtle, defaultMoveOpt))
-		b.AddParty(party1, party2)
+		party1 := NewOccupiedParty(GeneratePokemon(PkmnCharmander, defaultMoveOpt))
+		party2 := NewOccupiedParty(GeneratePokemon(PkmnSquirtle, defaultMoveOpt))
+		b.AddParty(party1, &_a1, 0)
+		b.AddParty(party2, &a2, 1)
 		Expect(b.Start()).To(Succeed())
 		a1 <- FightTurn{
 			Move: 0,

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,9 +31,9 @@ func (smartAgent) Act(ctx *BattleContext) Turn {
 	}
 }
 
-func randParty() *party {
+func randParty() *battleParty {
 	a1 := Agent(smartAgent{})
-	party := NewParty(&a1, 0)
+	party := newBattlePartyOld(&a1, 0)
 	count := rand.Intn(5) + 1
 	for j := 0; j < count; j++ {
 		p := GeneratePokemon(rand.Intn(493)+1,
@@ -57,7 +57,7 @@ func BenchmarkBattle(b *testing.B) {
 		p2 := randParty()
 		p2.team = 1
 		battle := NewBattle()
-		battle.AddParty(p1, p2)
+		battle.AddBattleParty(p1, p2)
 		err := battle.Start()
 		if err != nil {
 			panic(err)

--- a/http/api.go
+++ b/http/api.go
@@ -152,9 +152,7 @@ func HandleCreateBattle(w http.ResponseWriter, r *http.Request) {
 				wa := NewWaiterAgent()
 				a := Agent(wa)
 				hb.AgentInputs = append(hb.AgentInputs, wa.Input())
-				p := NewParty(&a, i)
-				p.AddPokemon(args.Parties[i]...)
-				hb.Battle.AddParty(p)
+				hb.Battle.AddParty(NewOccupiedParty(args.Parties[i]...), &a, i)
 			}
 		} else if len(args.Teams) > 0 {
 			for t, team := range args.Teams {
@@ -162,9 +160,7 @@ func HandleCreateBattle(w http.ResponseWriter, r *http.Request) {
 					wa := NewWaiterAgent()
 					a := Agent(wa)
 					hb.AgentInputs = append(hb.AgentInputs, wa.Input())
-					p := NewParty(&a, t)
-					p.AddPokemon(party.Pokemon...)
-					hb.Battle.AddParty(p)
+					hb.Battle.AddParty(NewOccupiedParty(party.Pokemon...), &a, t)
 				}
 			}
 		} else {

--- a/party.go
+++ b/party.go
@@ -6,45 +6,37 @@ import (
 	"log"
 )
 
-// A Pokemon party. Can hold up to 6 Pokemon. Also manages how many pokemon are out on the battlefield.
-type party struct {
-	Agent         *Agent           // The agent that has control over this party
-	pokemon       []*Pokemon       // The Pokemon in the party
-	activePokemon map[int]*Pokemon // Map containing slots and references to active Pokemon on the battlefield
-	team          int              // The team that this party belongs to
-	PokemonRules  PokemonValidationRules
-}
-
 // Maximum number of Pokemon in a party
 const MaxPartySize = 6
 
 var ErrorPartyIndex = errors.New("invalid index for party")
 var ErrorPartyFull = fmt.Errorf("party size cannot exceed max of %d Pokemon\n", MaxPartySize)
 
-// Creates a new party to store Pokemon and assigns them to a team
-func NewParty(agent *Agent, team int) *party {
-	return &party{
-		Agent:         agent,
-		pokemon:       make([]*Pokemon, 0),
-		activePokemon: make(map[int]*Pokemon),
-		team:          team,
-		PokemonRules:  PkmnRuleSetDefault,
+// A Party of Pokemon.
+type Party struct {
+	Pokemon      []*Pokemon
+	PokemonRules PokemonValidationRules
+}
+
+func NewParty() *Party {
+	return &Party{
+		Pokemon:      make([]*Pokemon, 0),
+		PokemonRules: PkmnRuleSetDefault,
 	}
 }
 
-// Creates a new party and fills it out with the passed Pokemon
-func NewOccupiedParty(agent *Agent, team int, pkmn ...*Pokemon) *party {
-	party := NewParty(agent, team)
-	err := party.AddPokemon(pkmn...)
+func NewOccupiedParty(pkmn ...*Pokemon) *Party {
+	p := NewParty()
+	err := p.AddPokemon(pkmn...)
 	if err != nil {
 		panic(err)
 	}
-	return party
+	return p
 }
 
 // Adds 1 or more Pokemon to a Party
-func (p *party) AddPokemon(pkmn ...*Pokemon) error {
-	if len(p.pokemon)+len(pkmn) > MaxPartySize {
+func (p *Party) AddPokemon(pkmn ...*Pokemon) error {
+	if len(p.Pokemon)+len(pkmn) > MaxPartySize {
 		return ErrorPartyFull
 	}
 	for i := range pkmn {
@@ -52,20 +44,37 @@ func (p *party) AddPokemon(pkmn ...*Pokemon) error {
 			return err
 		}
 	}
-	p.pokemon = append(p.pokemon, pkmn...)
+	p.Pokemon = append(p.Pokemon, pkmn...)
 	return nil
 }
 
+// A Pokemon battleParty. Can hold up to 6 Pokemon. Also manages how many pokemon are out on the battlefield. Only used inside of Battles.
+type battleParty struct {
+	Party         *Party
+	Agent         *Agent           // The agent that has control over this party
+	activePokemon map[int]*Pokemon // Map containing slots and references to active Pokemon on the battlefield
+	team          int              // The team that this party belongs to
+}
+
+func (p *battleParty) pokemon() []*Pokemon {
+	return p.Party.Pokemon
+}
+
+// Adds 1 or more Pokemon to a Party
+func (p *battleParty) AddPokemon(pkmn ...*Pokemon) error {
+	return p.Party.AddPokemon(pkmn...)
+}
+
 // Sets a Pokemon to be active by its index in a party (0-5)
-func (p *party) SetActive(i int) {
+func (p *battleParty) SetActive(i int) {
 	if p.IsActivePokemon(i) {
 		log.Panicf("pokemon is already out on the battlefield")
 	}
-	p.activePokemon[i] = p.pokemon[i]
+	p.activePokemon[i] = p.pokemon()[i]
 }
 
 // Sets a Pokemon to be inactive by its index in a party (0-5)
-func (p *party) SetInactive(i int) {
+func (p *battleParty) SetInactive(i int) {
 	if !p.IsActivePokemon(i) {
 		log.Panicf("pokemon is not out on the battlefield")
 	}
@@ -73,8 +82,8 @@ func (p *party) SetInactive(i int) {
 }
 
 // Checks if a Pokemon in a party is currently active
-func (p *party) IsActivePokemon(i int) bool {
-	if i >= len(p.pokemon) {
+func (p *battleParty) IsActivePokemon(i int) bool {
+	if i >= len(p.pokemon()) {
 		log.Panicln(ErrorPartyIndex)
 	}
 	if _, ok := p.activePokemon[i]; ok {
@@ -84,9 +93,9 @@ func (p *party) IsActivePokemon(i int) bool {
 }
 
 // Creates a map of party index to active Pokemon
-func (p *party) GetActivePokemon() map[int]Pokemon {
+func (p *battleParty) GetActivePokemon() map[int]Pokemon {
 	allActive := make(map[int]Pokemon)
-	for i, pokemon := range p.pokemon {
+	for i, pokemon := range p.pokemon() {
 		for _, active := range p.activePokemon {
 			if pokemon == active {
 				allActive[i] = *pokemon

--- a/party_test.go
+++ b/party_test.go
@@ -10,7 +10,7 @@ var _ = Describe("Party creation", func() {
 
 	Context("when adding Pokemon to a party", func() {
 		It("fails when adding too many Pokemon to a party", func() {
-			party := NewParty(&agent, 0)
+			party := newBattlePartyOld(&agent, 0)
 			for i := 0; i < MaxPartySize; i += 1 {
 				party.AddPokemon(GeneratePokemon(PkmnBulbasaur, WithMoves(MoveTackle)))
 			}
@@ -18,7 +18,7 @@ var _ = Describe("Party creation", func() {
 		})
 
 		It("fails when adding invalid pokemon to a party", func() {
-			party := NewParty(&agent, 0)
+			party := newBattlePartyOld(&agent, 0)
 			Expect(party.AddPokemon(GeneratePokemon(PkmnBulbasaur))).To(MatchError(ErrorValidationMissingMoves))
 		})
 	})
@@ -27,11 +27,11 @@ var _ = Describe("Party creation", func() {
 var _ = Describe("Active pokemon", func() {
 	agent := Agent(new(dumbAgent))
 	var (
-		party *party
+		party *battleParty
 	)
 
 	BeforeEach(func() {
-		party = NewOccupiedParty(&agent, 0,
+		party = newOccupiedBattleParty(&agent, 0,
 			GeneratePokemon(PkmnSquirtle, defaultMoveOpt),
 			GeneratePokemon(PkmnBlastoise, defaultMoveOpt),
 		)

--- a/transactions.go
+++ b/transactions.go
@@ -271,7 +271,7 @@ func (t FaintTransaction) Mutate(b *Battle) {
 	p := b.parties[t.Target.party]
 	p.SetInactive(t.Target.partySlot)
 	anyAlive := false
-	for i, pkmn := range p.pokemon {
+	for i, pkmn := range p.pokemon() {
 		if pkmn.CurrentHP > 0 {
 			anyAlive = true
 			// TODO: prompt Agent for which pokemon to send out next

--- a/util_test.go
+++ b/util_test.go
@@ -374,3 +374,40 @@ func AlwaysRNG() *TestRNG {
 func SimpleRNG() *TestRNG {
 	return &TestRNG{rolls: []bool{true, false}}
 }
+
+// Create a single Battle. A single battle is a battle where only 1 pokemon is sent out at a time, and there can only be 2 parties.
+// This function should only be used in tests.
+func NewSingleBattle(p1 *Party, a1 *Agent, p2 *Party, a2 *Agent) *Battle {
+	b := NewBattle()
+	b.AddParty(p1, a1, 0)
+	b.AddParty(p2, a2, 1)
+	return b
+}
+
+// Create a single Battle with only 1 pokemon in each party.
+// This function should only be used in tests.
+func New1v1Battle(p1 *Pokemon, a1 *Agent, p2 *Pokemon, a2 *Agent) *Battle {
+	return NewSingleBattle(NewOccupiedParty(p1), a1, NewOccupiedParty(p2), a2)
+}
+
+// Creates a new party to store Pokemon and assigns them to a team
+// This function should only be used in tests.
+func newBattlePartyOld(agent *Agent, team int) *battleParty {
+	return &battleParty{
+		Party:         NewParty(),
+		Agent:         agent,
+		activePokemon: make(map[int]*Pokemon),
+		team:          team,
+	}
+}
+
+// Creates a new party and fills it out with the passed Pokemon
+// This function should only be used in tests.
+func newOccupiedBattleParty(agent *Agent, team int, pkmn ...*Pokemon) *battleParty {
+	party := newBattlePartyOld(agent, team)
+	err := party.AddPokemon(pkmn...)
+	if err != nil {
+		panic(err)
+	}
+	return party
+}

--- a/util_test.go
+++ b/util_test.go
@@ -390,7 +390,7 @@ func New1v1Battle(p1 *Pokemon, a1 *Agent, p2 *Pokemon, a2 *Agent) *Battle {
 	return NewSingleBattle(NewOccupiedParty(p1), a1, NewOccupiedParty(p2), a2)
 }
 
-// Creates a new party to store Pokemon and assigns them to a team
+// Deprecated: Creates a new party to store Pokemon and assigns them to a team
 // This function should only be used in tests.
 func newBattlePartyOld(agent *Agent, team int) *battleParty {
 	return &battleParty{


### PR DESCRIPTION
This keeps but renames the old party type to `battleParty`, which performs
the same function as `party` did before. This will make it easier for users
to reuse a `Party` outside of a battle.

While I was at it, I also refactored most of the tests to be a little more
consistent, using new `NewSingleBattle` and `New1v1Battle` test utilities.

Related #237 