### PR TITLE
refactor damage calc, remove all float64

### DIFF
--- a/battle.go
+++ b/battle.go
@@ -366,7 +366,7 @@ func (b *Battle) SimulateRound() ([]Transaction, bool) {
 				}
 			} else {
 				// Physical/Special Moves
-				damage := calcMoveDamage(b.Weather, user, receiver, move)
+				damage := CalcMoveDamage(b.Weather, user, receiver, move)
 				var crit uint = 1
 				if b.rng.Roll(1, user.CritChance()) {
 					crit = 2

--- a/battle_test.go
+++ b/battle_test.go
@@ -206,11 +206,11 @@ var _ = Describe("One round of battle", func() {
 			charmander.Moves[0] = GetMove(MoveEmber)
 			Expect(battle.Start()).To(Succeed())
 			battle.SimulateRound()
-			Expect(bidoof.CurrentHP).To(BeEquivalentTo(7))
+			Expect(bidoof.CurrentHP).To(BeEquivalentTo(8))
 			bidoof.CurrentHP = 100
 			charmander.Ability = AbilityAdaptability
 			battle.SimulateRound()
-			Expect(bidoof.CurrentHP).To(BeEquivalentTo(93))
+			Expect(bidoof.CurrentHP).To(BeEquivalentTo(94))
 		})
 
 		Context("Type Matchups", func() {
@@ -742,7 +742,7 @@ var _ = Describe("Weather", func() {
 							partySlot: 0,
 							Team:      1,
 						},
-						Damage: 125,
+						Damage: 124,
 					},
 				))
 			})
@@ -945,7 +945,7 @@ var _ = Describe("Weather", func() {
 					Team:      0,
 				},
 				Move:   solarBeam,
-				Damage: 13,
+				Damage: 12,
 			}))
 			bulbasaur.Moves[0] = moonlight
 			bulbasaur.CurrentHP = bulbasaur.MaxHP()
@@ -960,7 +960,7 @@ var _ = Describe("Weather", func() {
 					Team:      1,
 				},
 				Move:   weatherBall,
-				Damage: 22,
+				Damage: 21,
 			}))
 			Expect(t).To(HaveTransaction(HealTransaction{
 				Target: bulbasaur,
@@ -1568,7 +1568,7 @@ var _ = Describe("Misc/held items", func() {
 					Team:      0,
 					Pokemon:   b.getPokemonInBattle(0, 0),
 				},
-				Damage: 34,
+				Damage: 32,
 			}))
 			// Take 10% of max HP
 			Expect(t).To(HaveTransaction(DamageTransaction{
@@ -1595,7 +1595,7 @@ var _ = Describe("Misc/held items", func() {
 					Team:      0,
 					Pokemon:   b.getPokemonInBattle(0, 0),
 				},
-				Damage: 28,
+				Damage: 27,
 			}))
 		})
 

--- a/calc.go
+++ b/calc.go
@@ -1,6 +1,6 @@
 package pokemonbattlelib
 
-func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damage uint) {
+func CalcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damage uint) {
 	// Compute base damage
 	levelEffect := uint((2 * user.Level / 5) + 2)
 	movePower := move.Power()

--- a/calc.go
+++ b/calc.go
@@ -1,34 +1,20 @@
 package pokemonbattlelib
 
 func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damage uint) {
-	weatherEffect := 1.0
-	if rain, sun := weather == WeatherRain, weather == WeatherHarshSunlight; (rain && move.Type() == TypeWater) || (sun && move.Type() == TypeFire) {
-		weatherEffect = 1.5
-	} else if (rain && move.Type() == TypeFire) || (sun && move.Type() == TypeWater) {
-		weatherEffect = 0.5
-	}
-	stab := 1.0
-	if move != nil && user.EffectiveType()&move.Type() != 0 {
-		stab = 1.5
-		if user.Ability == AbilityAdaptability {
-			stab = 2.0
-		}
-	}
-	// Compute damage modifier
-	modifier := weatherEffect * stab
-	levelEffect := float64((2 * user.Level / 5) + 2)
-	movePower := float64(move.Power())
-	attack := float64(user.Attack())
-	defense := float64(receiver.Defense())
+	// Compute base damage
+	levelEffect := uint((2 * user.Level / 5) + 2)
+	movePower := move.Power()
+	attack := user.Attack()
+	defense := receiver.Defense()
 	// Move modifiers
 	if move.Category() == MoveCategorySpecial {
-		attack = float64(user.SpecialAttack())
-		defense = float64(receiver.SpecialDefense())
+		attack = user.SpecialAttack()
+		defense = receiver.SpecialDefense()
 	}
 	// Weather modifiers
 	if weather == WeatherSandstorm {
 		if receiver.EffectiveType()&TypeRock != 0 {
-			defense *= 1.5
+			defense *= (defense * 150) / 100
 		}
 		if move.Id == MoveSolarBeam {
 			movePower /= 2
@@ -44,25 +30,43 @@ func calcMoveDamage(weather Weather, user, receiver *Pokemon, move *Move) (damag
 			movePower /= 2
 		}
 	}
-	// Item modifiers
-	switch user.HeldItem {
-	case ItemLifeOrb:
-		modifier = (modifier * 130) / 100
-	case ItemMuscleBand:
-		if move.Category() == MoveCategoryPhysical {
-			modifier = (modifier * 110) / 100
-		}
-	case ItemWiseGlasses:
-		if move.Category() == MoveCategorySpecial {
-			modifier = (modifier * 110) / 100
-		}
-	}
-	damage = uint((((levelEffect * movePower * attack / defense) / 50) + 2) * modifier)
+	damage = uint((((levelEffect * movePower * attack / defense) / 50) + 2))
+
+	// apply modifiers
 	elementalEffect := GetElementalEffect(move.Type(), receiver.EffectiveType())
 	if elementalEffect > NormalEffect {
 		damage <<= elementalEffect
 	} else if elementalEffect < NormalEffect {
 		damage >>= elementalEffect * -1 // bitshift operand must be positive
 	}
+
+	if rain, sun := weather == WeatherRain, weather == WeatherHarshSunlight; (rain && move.Type() == TypeWater) || (sun && move.Type() == TypeFire) {
+		damage = (damage * 150) / 100
+	} else if (rain && move.Type() == TypeFire) || (sun && move.Type() == TypeWater) {
+		damage /= 2
+	}
+
+	if move != nil && user.EffectiveType()&move.Type() != 0 {
+		if user.Ability == AbilityAdaptability {
+			damage *= 2
+		} else {
+			damage = (damage * 150) / 100
+		}
+	}
+
+	// Item modifiers
+	switch user.HeldItem {
+	case ItemLifeOrb:
+		damage = (damage * 130) / 100
+	case ItemMuscleBand:
+		if move.Category() == MoveCategoryPhysical {
+			damage = (damage * 110) / 100
+		}
+	case ItemWiseGlasses:
+		if move.Category() == MoveCategorySpecial {
+			damage = (damage * 110) / 100
+		}
+	}
+
 	return damage
 }


### PR DESCRIPTION
closes #78

This removes all usage of float64﻿ when calculating move damage to fix rounding errors. All divisions in pokemon are floor divides anyway. It also adjusts all the related tests so that they are no longer off by 1.

This also makes `calcMoveDamage` public so that it can be used in agents externally.
