### PR TITLE
refactor all tests to use PkmnWithMoves instead

### DIFF
--- a/battle_item_test.go
+++ b/battle_item_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Medicine Items", func() {
 		a2 = newRcAgent()
 		_a2 := Agent(a2)
 		user := GeneratePokemon(PkmnBulbasaur, WithLevel(100), WithMoves(MoveSplash))
-		p2 := GeneratePokemon(PkmnCharmander, WithMoves(MoveSplash))
+		p2 := PkmnWithMoves(MoveSplash)
 		b := New1v1Battle(user, &a1, p2, &_a2)
 		Expect(b.Start()).To(Succeed())
 		a2 <- ItemTurn{
@@ -516,7 +516,7 @@ var _ = Describe("Battle Items", func() {
 		_a1 := Agent(a1)
 		a2 = Agent(new(dumbAgent))
 		user := GeneratePokemon(PkmnBulbasaur, WithLevel(100), WithMoves(MoveSplash))
-		p2 := GeneratePokemon(PkmnCharmander, WithMoves(MoveSplash))
+		p2 := PkmnWithMoves(MoveSplash)
 		b := New1v1Battle(user, &_a1, p2, &a2)
 		Expect(b.Start()).To(Succeed())
 		a1 <- ItemTurn{

--- a/battle_move_effects_test.go
+++ b/battle_move_effects_test.go
@@ -21,8 +21,8 @@ var _ = Describe("Stat-changing moves", func() {
 
 	DescribeTable("Should modify the User's stats",
 		func(id MoveId, stat, stages int) {
-			charmander := GeneratePokemon(PkmnCharmander, WithMoves(id))
-			squirtle := GeneratePokemon(PkmnSquirtle, WithMoves(MovePound))
+			charmander := PkmnWithMoves(id)
+			squirtle := PkmnWithMoves(MovePound)
 			battle := New1v1Battle(charmander, &agent1, squirtle, &agent1)
 			battle.rng = SimpleRNG()
 			Expect(battle.Start()).To(Succeed())
@@ -51,8 +51,8 @@ var _ = Describe("Stat-changing moves", func() {
 
 	DescribeTable("Should modify the Opponents's stats",
 		func(id MoveId, stat, stages int) {
-			charmander := GeneratePokemon(PkmnCharmander, WithMoves(id))
-			squirtle := GeneratePokemon(PkmnSquirtle, WithMoves(MovePound))
+			charmander := PkmnWithMoves(id)
+			squirtle := PkmnWithMoves(MovePound)
 			battle := New1v1Battle(charmander, &agent1, squirtle, &agent1)
 			battle.rng = AlwaysRNG()
 			Expect(battle.Start()).To(Succeed())

--- a/battle_move_test.go
+++ b/battle_move_test.go
@@ -24,8 +24,8 @@ var _ = Describe("Move PP Consumption", func() {
 	a := Agent(new(dumbAgent))
 	It("should decrement move's PP by 1 when used", func() {
 		b := New1v1Battle(
-			GeneratePokemon(PkmnSquirtle, WithMoves(TestMoveNoDamage)), &a,
-			GeneratePokemon(PkmnSquirtle, WithMoves(TestMoveNoDamage)), &a,
+			PkmnWithMoves(TestMoveNoDamage), &a,
+			PkmnWithMoves(TestMoveNoDamage), &a,
 		)
 		b.rng = AlwaysRNG()
 		Expect(b.Start()).To(Succeed())

--- a/battle_test.go
+++ b/battle_test.go
@@ -322,11 +322,11 @@ var _ = Describe("Getting pokemon from parties", func() {
 
 	BeforeEach(func() {
 		p1 := NewOccupiedParty(
-			GeneratePokemon(PkmnCharmander, WithMoves(TestMoveDefault)),
-			GeneratePokemon(PkmnSquirtle, WithMoves(TestMoveDefault)),
-			GeneratePokemon(PkmnMetapod, WithMoves(TestMoveDefault)),
+			PkmnWithMoves(TestMoveDefault),
+			PkmnWithMoves(TestMoveDefault),
+			PkmnWithMoves(TestMoveDefault),
 		)
-		p2 := NewOccupiedParty(GeneratePokemon(PkmnBeedrill, WithMoves(TestMoveDefault)))
+		p2 := NewOccupiedParty(PkmnWithMoves(TestMoveDefault))
 		b = NewSingleBattle(p1, &a1, p2, &a2)
 	})
 
@@ -433,8 +433,8 @@ var _ = Describe("Turn priority", func() {
 		})
 
 		It("should handle faster Pokemon first", func() {
-			p1 := GeneratePokemon(PkmnCharmander, WithMoves(TestMoveDefault))
-			p2 := GeneratePokemon(PkmnNinjask, WithMoves(TestMoveDefault)) // ninjask is faster than charmander
+			p1 := PkmnWithMoves(TestMoveDefault)
+			p2 := PkmnWithMoves(TestMoveDefault) // ninjask is faster than charmander
 			b := New1v1Battle(p1, &a1, p2, &a2)
 			b.rng = SimpleRNG()
 			Expect(b.Start()).To(Succeed())
@@ -619,8 +619,8 @@ var _ = Describe("Weather", func() {
 			})
 
 			It("should cause sandstorm damage", func() {
-				bidoof := GeneratePokemon(PkmnBidoof, WithMoves(MoveTackle))
-				bulbasaur := GeneratePokemon(PkmnBulbasaur, WithMoves(MoveSolarBeam))
+				bidoof := PkmnWithMoves(MoveTackle)
+				bulbasaur := PkmnWithMoves(MoveSolarBeam)
 				b := New1v1Battle(bidoof, &a1, bulbasaur, &a2)
 				b.rng = SimpleRNG()
 				b.Weather = WeatherHail
@@ -675,8 +675,8 @@ var _ = Describe("Weather", func() {
 			})
 
 			It("should cause hail damage", func() {
-				bidoof := GeneratePokemon(PkmnBidoof, WithMoves(MoveTackle))
-				bulbasaur := GeneratePokemon(PkmnBulbasaur, WithMoves(MoveSolarBeam))
+				bidoof := PkmnWithMoves(MoveTackle)
+				bulbasaur := PkmnWithMoves(MoveSolarBeam)
 				b := New1v1Battle(bidoof, &a1, bulbasaur, &a2)
 				b.rng = SimpleRNG()
 				b.Weather = WeatherHail
@@ -825,7 +825,7 @@ var _ = Describe("Fainting", func() {
 
 		It("should gain EVs when defeating Pokemon", func() {
 			winner := PkmnDefault()
-			loser := GeneratePokemon(PkmnBulbasaur, WithMoves(TestMoveDefault))
+			loser := PkmnWithMoves(TestMoveDefault)
 			loser.CurrentHP = 1
 			p1 = NewOccupiedParty(winner)
 			p2 = NewOccupiedParty(loser)
@@ -933,8 +933,8 @@ var _ = Describe("Battle metadata", func() {
 	Context("Pokemon metadata", func() {
 		It("should record the last used move of Pokemon in battle", func() {
 			a1 := Agent(new(dumbAgent))
-			p1 := GeneratePokemon(PkmnBulbasaur, WithMoves(MoveRazorLeaf))
-			p2 := GeneratePokemon(PkmnCharmander, WithMoves(MoveEmber))
+			p1 := PkmnWithMoves(MoveRazorLeaf)
+			p2 := PkmnWithMoves(MoveEmber)
 			b := New1v1Battle(p1, &a1, p2, &a1)
 			b.rng = SimpleRNG()
 			Expect(b.Start()).To(Succeed())
@@ -952,8 +952,8 @@ var _ = Describe("Status Conditions", func() {
 
 	Context("when using certain moves in battle causes status effects", func() {
 		It("should inflict paralysis from MoveStunSpore", func() {
-			pkmn1 := GeneratePokemon(PkmnBulbasaur, WithMoves(MoveSplash))
-			pkmn2 := GeneratePokemon(PkmnBulbasaur, WithMoves(MoveStunSpore))
+			pkmn1 := PkmnWithMoves(MoveSplash)
+			pkmn2 := PkmnWithMoves(MoveStunSpore)
 			b := New1v1Battle(pkmn1, &a1, pkmn2, &a2)
 			b.rng = AlwaysRNG()
 			Expect(b.Start()).To(Succeed())

--- a/party_test.go
+++ b/party_test.go
@@ -12,9 +12,9 @@ var _ = Describe("Party creation", func() {
 		It("fails when adding too many Pokemon to a party", func() {
 			party := newBattlePartyOld(&agent, 0)
 			for i := 0; i < MaxPartySize; i += 1 {
-				party.AddPokemon(GeneratePokemon(PkmnBulbasaur, WithMoves(MoveTackle)))
+				party.AddPokemon(PkmnWithMoves(MoveTackle))
 			}
-			Expect(party.AddPokemon(GeneratePokemon(PkmnBulbasaur, WithMoves(MoveTackle)))).To(MatchError(ErrorPartyFull))
+			Expect(party.AddPokemon(PkmnWithMoves(MoveTackle))).To(MatchError(ErrorPartyFull))
 		})
 
 		It("fails when adding invalid pokemon to a party", func() {
@@ -32,8 +32,8 @@ var _ = Describe("Active pokemon", func() {
 
 	BeforeEach(func() {
 		party = newOccupiedBattleParty(&agent, 0,
-			GeneratePokemon(PkmnSquirtle, WithMoves(TestMoveDefault)),
-			GeneratePokemon(PkmnBlastoise, WithMoves(TestMoveDefault)),
+			PkmnWithMoves(TestMoveDefault),
+			PkmnWithMoves(TestMoveDefault),
 		)
 	})
 

--- a/pokemon_test.go
+++ b/pokemon_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Pokemon generation", func() {
 
 	Describe("Validation", func() {
 		It("succeeds when the pokemon has moves", func() {
-			p := GeneratePokemon(PkmnPikachu, WithMoves(MoveThunder))
+			p := PkmnWithMoves(MoveThunder)
 			Expect(p.Validate(PkmnRuleSetDefault)).To(Succeed())
 		})
 
@@ -126,25 +126,25 @@ var _ = Describe("Pokemon generation", func() {
 		})
 
 		It("fails when the pokemon has invalid level", func() {
-			p := GeneratePokemon(PkmnPikachu, WithMoves(MoveThunder))
+			p := PkmnWithMoves(MoveThunder)
 			p.Ability = 0
 			Expect(p.Validate(PkmnRuleSetDefault)).To(MatchError(ErrorValidationMissingAbility))
 		})
 
 		It("fails when the pokemon has invalid level", func() {
-			p := GeneratePokemon(PkmnPikachu, WithMoves(MoveThunder))
+			p := PkmnWithMoves(MoveThunder)
 			p.Level = 0
 			Expect(p.Validate(PkmnRuleSetDefault)).To(MatchError(ErrorValidationInvalidLevel))
 		})
 
 		It("fails when the pokemon has invalid IVs", func() {
-			p := GeneratePokemon(PkmnPikachu, WithMoves(MoveThunder))
+			p := PkmnWithMoves(MoveThunder)
 			p.IVs[StatHP] = 255
 			Expect(p.Validate(PkmnRuleSetDefault)).To(MatchError(ErrorValidationInvalidIvs))
 		})
 
 		It("fails when the pokemon has invalid EVs", func() {
-			p := GeneratePokemon(PkmnPikachu, WithMoves(MoveThunder))
+			p := PkmnWithMoves(MoveThunder)
 			p.EVs[StatHP] = 255
 			Expect(p.Validate(PkmnRuleSetDefault)).To(MatchError(ErrorValidationInvalidEvs))
 		})


### PR DESCRIPTION
Generated with:

```
gofmt -r 'GeneratePokemon(b, WithMoves(a)) -> PkmnWithMoves(a)' -w *.go
``﻿`

I'm not sure if we want to do this right now because we need to change `PkmnWithMoves` and others to use a new `RegisterPokemon` function that works how `RegisterMove` works.
