### PR TITLE
Document move meta categories, and add a test for MoveMetaCategoryDamageRaise

### DIFF
--- a/battle_move_effects_test.go
+++ b/battle_move_effects_test.go
@@ -121,6 +121,27 @@ var _ = Describe("Move Effects", func() {
 			},
 		))
 	})
+
+	PIt("should deal damage and modify the user's stat (MoveMetaCategoryDamageRaise)", func() {
+		b := New1v1Battle(
+			GeneratePokemon(PkmnMightyena, WithLevel(20), WithMoves(TestMoveDamageAndStatChangeSelf)), &a1,
+			GeneratePokemon(PkmnPonyta, WithLevel(20), WithMoves(TestMoveNoDamage)), &a1,
+		)
+		b.rng = AlwaysRNG()
+		Expect(b.Start()).To(Succeed())
+		t, _ := b.SimulateRound()
+		Expect(t).To(HaveTransactionsInOrder(
+			DamageTransaction{
+				Target: target{1, 0},
+			},
+			ModifyStatTransaction{
+				Target:        target{0, 0},
+				SelfInflicted: true,
+				Stat:          int(b.getPokemon(target{0, 0}).Moves[0].AffectedStat()),
+				Stages:        int(b.getPokemon(target{0, 0}).Moves[0].StatStages()),
+			},
+		))
+	})
 })
 
 var _ = Describe("Draining moves", func() {

--- a/battle_move_test.go
+++ b/battle_move_test.go
@@ -18,6 +18,7 @@ var TestMoveDefault = RegisterMove(MoveData{Name: "Default", Category: MoveCateg
 var TestMoveNoDamage = RegisterMove(MoveData{Name: "No Damage", InitialMaxPP: 100})
 var TestMoveInflictBurn = RegisterMove(MoveData{Name: "Inflict Burn", Category: MoveCategoryStatus, InitialMaxPP: 100, Ailment: StatusBurn})
 var TestMoveDamageAndInflictBurn = RegisterMove(MoveData{Name: "Damage and Inflict Burn", Category: MoveCategoryPhysical, InitialMaxPP: 100, AilmentChance: 100, Ailment: StatusBurn, Power: 10})
+var TestMoveDamageAndStatChangeSelf = RegisterMove(MoveData{Name: "Damage and Modify user's stat", Category: MoveCategoryPhysical, MetaCategory: MoveMetaCategoryDamageRaise, InitialMaxPP: 100, Power: 10, StatChance: 100, AffectedStat: StatAtk, StatStages: 2})
 
 var _ = Describe("Move Status Inflict", func() {
 	a := Agent(new(dumbAgent))

--- a/move.go
+++ b/move.go
@@ -51,20 +51,20 @@ const (
 type MoveMetaCategory uint8
 
 const (
-	MoveMetaCategoryDamage MoveMetaCategory = iota
-	MoveMetaCategoryAilment
-	MoveMetaCategoryNetGoodStats
-	MoveMetaCategoryHeal
-	MoveMetaCategoryDamageAilment
-	MoveMetaCategorySwagger
-	MoveMetaCategoryDamageLower
-	MoveMetaCategoryDamageRaise
-	MoveMetaCategoryDamageHeal
-	MoveMetaCategoryOhko // One hit knock out
-	MoveMetaCategoryWholeFieldEffect
-	MoveMetaCategoryFieldEffect
-	MoveMetaCategoryForceSwitch
-	MoveMetaCategoryUnique
+	MoveMetaCategoryDamage           MoveMetaCategory = iota // Deal damage to target pokemon.
+	MoveMetaCategoryAilment                                  // Apply a status condition to the target of the move.
+	MoveMetaCategoryNetGoodStats                             // Modify the target pokemon's stats.
+	MoveMetaCategoryHeal                                     // Heals the user or a target ally.
+	MoveMetaCategoryDamageAilment                            // Deal damage to target pokemon, and have a chance to apply a status condition to the target of the move.
+	MoveMetaCategorySwagger                                  // Raise the target's stats, and apply confusion.
+	MoveMetaCategoryDamageLower                              // Deal damage to target pokemon, and have a chance to apply a stat modifier to the target of the move.
+	MoveMetaCategoryDamageRaise                              // Deal damage to target pokemon, and have a chance to apply a stat modifier to the user of the move.
+	MoveMetaCategoryDamageHeal                               // Deal damage to target pokemon, and restore some of the user's HP. However, this is effectively a noop, because this functionality is only present on moves that have `Drain != 0`.
+	MoveMetaCategoryOhko                                     // One hit knock out. If the move hits the target pokemon, it is generally guarenteed to die (there are exceptions). Always fails if the target pokemon's level is greater than the user's level.
+	MoveMetaCategoryWholeFieldEffect                         // Applies a special effect to the entire battlefield (usually weather).
+	MoveMetaCategoryFieldEffect                              // Applies a special effect to the user's side of the battlefield.
+	MoveMetaCategoryForceSwitch                              // Forces the target pokemon to switch out.
+	MoveMetaCategoryUnique                                   // For moves that have specific, one-off rules.
 )
 
 type MoveFlags uint32

--- a/move.go
+++ b/move.go
@@ -60,7 +60,7 @@ const (
 	MoveMetaCategoryDamageLower                              // Deal damage to target pokemon, and have a chance to apply a stat modifier to the target of the move.
 	MoveMetaCategoryDamageRaise                              // Deal damage to target pokemon, and have a chance to apply a stat modifier to the user of the move.
 	MoveMetaCategoryDamageHeal                               // Deal damage to target pokemon, and restore some of the user's HP. However, this is effectively a noop, because this functionality is only present on moves that have `Drain != 0`.
-	MoveMetaCategoryOhko                                     // One hit knock out. If the move hits the target pokemon, it is generally guarenteed to die (there are exceptions). Always fails if the target pokemon's level is greater than the user's level.
+	MoveMetaCategoryOhko                                     // One hit knock out. If the move hits the target pokemon, it is generally guaranteed to die (there are exceptions). Always fails if the target pokemon's level is greater than the user's level.
 	MoveMetaCategoryWholeFieldEffect                         // Applies a special effect to the entire battlefield (usually weather).
 	MoveMetaCategoryFieldEffect                              // Applies a special effect to the user's side of the battlefield.
 	MoveMetaCategoryForceSwitch                              // Forces the target pokemon to switch out.


### PR DESCRIPTION
- document all move meta categories
- add a test for MoveMetaCategoryDamageRaise (#379)

This does NOT close the issue #379. It adds a pending test that is skipped, but can be enabled when #379 is implemented.
